### PR TITLE
fix: prevent Provider to be regenerated

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "drama-queen-container",
   "private": true,
-  "version": "1.3.18",
+  "version": "1.3.19",
   "workspaces": [
     "drama-queen",
     "queen-v2",
@@ -23,5 +23,8 @@
     "kill-port": "^2.0.1",
     "lerna": "^6.5.1",
     "vite-tsconfig-paths": "^4.0.5"
+  },
+  "volta": {
+    "node": "16.20.2"
   }
 }

--- a/queen-v2/package.json
+++ b/queen-v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "queen-v2",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "Web application for the management of questionnaires powered by Lunatic",
   "repository": {
     "type": "git",

--- a/queen-v2/src/components/lightOrchestrator/lightOrchestrator.js
+++ b/queen-v2/src/components/lightOrchestrator/lightOrchestrator.js
@@ -1,5 +1,5 @@
 import { useLunatic } from '@inseefr/lunatic';
-import { memo, useEffect, useMemo, useRef } from 'react';
+import {memo, useEffect, useMemo, useRef, useState} from 'react';
 import ButtonContinue from './buttons/continue/index';
 import D from 'i18n';
 import { isSequenceOrSubsequenceComponent } from 'utils/components/deduceState';
@@ -18,6 +18,7 @@ function noDataChange() {
 
 const preferences = ['COLLECTED'];
 const features = ['VTL', 'MD'];
+const custom = { RouterLink: Link }
 
 const missingShortcut = { dontKnow: 'f2', refused: 'f4' };
 
@@ -68,7 +69,7 @@ function LightOrchestrator({
   });
 
   lunaticStateRef.current = useLunatic(source, initialData, {
-    custom: { RouterLink: Link },
+    custom,
     lastReachedPage: lastReachedPage ?? '1',
     features,
     pagination,

--- a/queen-v2/src/components/lightOrchestrator/lightOrchestrator.js
+++ b/queen-v2/src/components/lightOrchestrator/lightOrchestrator.js
@@ -1,5 +1,5 @@
 import { useLunatic } from '@inseefr/lunatic';
-import {memo, useEffect, useMemo, useRef, useState} from 'react';
+import { memo, useEffect, useMemo, useRef } from 'react';
 import ButtonContinue from './buttons/continue/index';
 import D from 'i18n';
 import { isSequenceOrSubsequenceComponent } from 'utils/components/deduceState';
@@ -18,7 +18,7 @@ function noDataChange() {
 
 const preferences = ['COLLECTED'];
 const features = ['VTL', 'MD'];
-const custom = { RouterLink: Link }
+const custom = { RouterLink: Link };
 
 const missingShortcut = { dontKnow: 'f2', refused: 'f4' };
 


### PR DESCRIPTION
## Cause

Custom étant passé sous forme d'objet, le <Provider> est regénéré ce qui fait qu'on avait une nouvelle instance à chaque rendu, ce qui se voit maintenant avec l'auto-focus.

Fix #86 