### PR TITLE
fix: optional keys for collected values

### DIFF
--- a/drama-queen/src/core/adapters/queenApi/parserSchema/surveyUnitDataSchema.ts
+++ b/drama-queen/src/core/adapters/queenApi/parserSchema/surveyUnitDataSchema.ts
@@ -9,13 +9,15 @@ const variableSchema = z
   ])
   .nullable()
 
-const collectedValueSchema = z.object({
-  COLLECTED: variableSchema,
-  EDITED: variableSchema,
-  FORCED: variableSchema,
-  INPUTED: variableSchema,
-  PREVIOUS: variableSchema,
-})
+const collectedValueSchema = z
+  .object({
+    COLLECTED: variableSchema,
+    EDITED: variableSchema,
+    FORCED: variableSchema,
+    INPUTED: variableSchema,
+    PREVIOUS: variableSchema,
+  })
+  .partial()
 
 export const surveyUnitDataSchema = z
   .object({

--- a/drama-queen/src/core/model/SurveyUnitData.ts
+++ b/drama-queen/src/core/model/SurveyUnitData.ts
@@ -9,9 +9,11 @@ type VariableType =
   | (string | null | number | boolean)[]
   | null
 
-export type CollectedValues = Record<
-  'COLLECTED' | 'EDITED' | 'FORCED' | 'INPUTED' | 'PREVIOUS',
-  VariableType
+export type CollectedValues = Partial<
+  Record<
+    'COLLECTED' | 'EDITED' | 'FORCED' | 'INPUTED' | 'PREVIOUS',
+    VariableType
+  >
 >
 
 //Extends because we are more specific (lunatic use unknown)


### PR DESCRIPTION
Collected objects (edited, forced, ...) must be optional in surveyUnitData