### PR TITLE
fix: axios errors missing response status

### DIFF
--- a/drama-queen/src/core/adapters/queenApi/default.ts
+++ b/drama-queen/src/core/adapters/queenApi/default.ts
@@ -49,7 +49,7 @@ export function createApiClient(params: {
         if (!(error instanceof AxiosError)) {
           return Promise.reject(error)
         }
-        handleAxiosError(error)
+        return Promise.reject(handleAxiosError(error))
       }
     )
     return { axiosInstance }

--- a/drama-queen/src/core/tools/axiosError.ts
+++ b/drama-queen/src/core/tools/axiosError.ts
@@ -5,30 +5,26 @@ const { t } = getTranslation('errorMessage')
 
 export function handleAxiosError(error: AxiosError) {
   if (!error.response) {
-    throw new AxiosError(
+    error.message =
       "Une erreur s'est produite lors du traitement de la requête. Veuillez réessayer plus tard."
-    )
+    return error
   }
+
   const status = error.response.status
-  switch (status) {
-    case 400:
-      throw new AxiosError(t('400'))
-    case 401:
-      throw new AxiosError(t('401'))
-    case 403:
-      throw new AxiosError(t('403'))
-    case 404:
-      throw new AxiosError(t('404'))
-      break
-    case 500:
-      throw new AxiosError(t('500'))
-    case 502:
-      throw new AxiosError(t('502'))
-    case 503:
-      throw new AxiosError(t('503'))
-    case 504:
-      throw new AxiosError(t('504'))
-    default:
-      throw new AxiosError(t('longUnknownError'))
+  console.error(`Axios error with status ${status}:`, error.response.data)
+
+  const messages: { [key: number]: string } = {
+    400: t('400'),
+    401: t('401'),
+    403: t('403'),
+    404: t('404'),
+    500: t('500'),
+    502: t('502'),
+    503: t('503'),
+    504: t('504'),
   }
+
+  error.message = messages[status] || t('longUnknownError')
+
+  return error
 }

--- a/drama-queen/src/core/tools/axiosError.ts
+++ b/drama-queen/src/core/tools/axiosError.ts
@@ -11,7 +11,6 @@ export function handleAxiosError(error: AxiosError) {
   }
 
   const status = error.response.status
-  console.error(`Axios error with status ${status}:`, error.response.data)
 
   const messages: { [key: number]: string } = {
     400: t('400'),


### PR DESCRIPTION
- #247 

Since internalization of axios errors, the thrown errors were missing response, so during synchronization every treatments checking response status (400, 500 ...) were not working.
For some cases as when trying to put surveyUnit, it leaded to a failure so synchronization stoped

Still, I kept the idea of adding a personalized message in axios errors depending on response code