### PR TITLE
refactor: remove multiple imports + uppercase constants

### DIFF
--- a/drama-queen/src/core/constants.ts
+++ b/drama-queen/src/core/constants.ts
@@ -1,2 +1,4 @@
+export const DYNAMIC_PUBLIC_URL = new URL(import.meta.url).origin
 export const EXTERNAL_RESOURCES_URL = import.meta.env
   .VITE_EXTERNAL_RESOURCES_URL
+export const LUNATIC_MODEL_VERSION_BREAKING = '2.2.10'

--- a/drama-queen/src/core/constants.ts
+++ b/drama-queen/src/core/constants.ts
@@ -1,0 +1,2 @@
+export const EXTERNAL_RESOURCES_URL = import.meta.env
+  .VITE_EXTERNAL_RESOURCES_URL

--- a/drama-queen/src/core/index.ts
+++ b/drama-queen/src/core/index.ts
@@ -8,5 +8,3 @@ import { bootstrapCore } from 'core/bootstrap'
 export const { createCoreProvider, useCore, useCoreState } = createReactApi({
   bootstrapCore,
 })
-
-export const DYNAMIC_PUBLIC_URL = new URL(import.meta.url).origin

--- a/drama-queen/src/core/tools/SurveyModelBreaking.ts
+++ b/drama-queen/src/core/tools/SurveyModelBreaking.ts
@@ -1,7 +1,6 @@
+import { LUNATIC_MODEL_VERSION_BREAKING } from 'core/constants'
 import type { Questionnaire } from 'core/model'
 import { getTranslation } from 'i18n'
-
-export const LUNATIC_MODEL_VERSION_BREAKING = '2.2.10'
 
 const { t } = getTranslation('errorMessage')
 

--- a/drama-queen/src/core/tools/SurveyModelBreaking.ts
+++ b/drama-queen/src/core/tools/SurveyModelBreaking.ts
@@ -1,7 +1,7 @@
 import type { Questionnaire } from 'core/model'
 import { getTranslation } from 'i18n'
 
-export const lunaticModelVersionBreaking = '2.2.10'
+export const LUNATIC_MODEL_VERSION_BREAKING = '2.2.10'
 
 const { t } = getTranslation('errorMessage')
 
@@ -23,5 +23,7 @@ export const isSurveyCompatibleWithQueen = (params: {
     return true
   }
 
-  return semverCompare(lunaticModelVersion, lunaticModelVersionBreaking) === 1
+  return (
+    semverCompare(lunaticModelVersion, LUNATIC_MODEL_VERSION_BREAKING) === 1
+  )
 }

--- a/drama-queen/src/core/tools/externalResources.test.ts
+++ b/drama-queen/src/core/tools/externalResources.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest'
 import {
-  externalResourcesUrl,
   filterTransformedManifest,
   getExternalQuestionnaireFiltered,
   getExternalQuestionnaires,
@@ -15,6 +14,7 @@ import type {
   ExternalQuestionnairesWrapper,
   Manifest,
 } from 'core/model'
+import { EXTERNAL_RESOURCES_URL } from 'core/constants'
 
 vi.mock('./fetchUrl', () => {
   return {
@@ -40,7 +40,7 @@ describe('getExternalQuestionnaires', () => {
 
     // Assert fetchUrl was called with the correct url
     expect(fetchUrl).toHaveBeenCalledWith({
-      url: `${externalResourcesUrl}/gide-questionnaires.json`,
+      url: `${EXTERNAL_RESOURCES_URL}/gide-questionnaires.json`,
     })
 
     expect(result).toEqual(questionnairesList.questionnaires)
@@ -75,12 +75,12 @@ describe('getTransformedManifest', () => {
 
     // Assert fetchUrl was called with the correct URL
     expect(fetchUrl).toHaveBeenCalledWith({
-      url: `${externalResourcesUrl}/${questionnaireId}/assets-manifest.json`,
+      url: `${EXTERNAL_RESOURCES_URL}/${questionnaireId}/assets-manifest.json`,
     })
 
     const expectedResult = [
-      `${externalResourcesUrl}/qt/resource1`,
-      `${externalResourcesUrl}/qt/resource2`,
+      `${EXTERNAL_RESOURCES_URL}/qt/resource1`,
+      `${EXTERNAL_RESOURCES_URL}/qt/resource2`,
     ]
 
     expect(result).toEqual(expectedResult)

--- a/drama-queen/src/core/tools/externalResources.ts
+++ b/drama-queen/src/core/tools/externalResources.ts
@@ -8,7 +8,7 @@ import type {
 import { fetchUrl } from './fetchUrl'
 import { EXTERNAL_RESOURCES_URL } from 'core/constants'
 
-const externalQuestionnairesKeyword = 'gide'
+const EXTERNAL_QUESTIONNAIRES_KEYWORD = 'gide'
 
 // Get the list of external questionnaires
 export async function getExternalQuestionnaires(): Promise<ExternalQuestionnaires> {
@@ -121,7 +121,7 @@ export async function getOldExternalCacheNames(
     (cacheName) =>
       cacheName
         .toLowerCase()
-        .includes(externalQuestionnairesKeyword.toLowerCase()) &&
+        .includes(EXTERNAL_QUESTIONNAIRES_KEYWORD.toLowerCase()) &&
       !neededCaches.includes(cacheName)
   )
 

--- a/drama-queen/src/core/tools/externalResources.ts
+++ b/drama-queen/src/core/tools/externalResources.ts
@@ -6,14 +6,14 @@ import type {
   Manifest,
 } from 'core/model'
 import { fetchUrl } from './fetchUrl'
+import { EXTERNAL_RESOURCES_URL } from 'core/constants'
 
-export const externalResourcesUrl = import.meta.env.VITE_EXTERNAL_RESOURCES_URL
 const externalQuestionnairesKeyword = 'gide'
 
 // Get the list of external questionnaires
 export async function getExternalQuestionnaires(): Promise<ExternalQuestionnaires> {
   const questionnairesWrapper = await fetchUrl<ExternalQuestionnairesWrapper>({
-    url: `${externalResourcesUrl}/gide-questionnaires.json`,
+    url: `${EXTERNAL_RESOURCES_URL}/gide-questionnaires.json`,
   })
 
   return questionnairesWrapper.questionnaires
@@ -25,12 +25,12 @@ export async function getTransformedManifest(
 ): Promise<string[]> {
   // get the manifest for a questionnaireId
   const manifest = await fetchUrl<Manifest>({
-    url: `${externalResourcesUrl}/${questionnaireId}/assets-manifest.json`,
+    url: `${EXTERNAL_RESOURCES_URL}/${questionnaireId}/assets-manifest.json`,
   })
 
   // Transform the manifest values into resource URLs, and get an array of these resource URLs
   const transformedManifest = Object.values(manifest).map(
-    (resourceUrl) => `${externalResourcesUrl}/${resourceUrl}`
+    (resourceUrl) => `${EXTERNAL_RESOURCES_URL}/${resourceUrl}`
   )
 
   return transformedManifest

--- a/drama-queen/src/core/usecases/synchronizeData/state.ts
+++ b/drama-queen/src/core/usecases/synchronizeData/state.ts
@@ -1,7 +1,7 @@
 import { createUsecaseActions } from 'redux-clean-architecture'
 import { id } from 'tsafe/id'
 import { assert } from 'tsafe/assert'
-import { externalResourcesUrl } from 'core/tools/externalResources'
+import { EXTERNAL_RESOURCES_URL } from 'core/constants'
 
 export type State = State.NotRunning | State.Running
 
@@ -60,7 +60,7 @@ export const { reducer, actions } = createUsecaseActions({
           // for total external resources, we make difference for displaying progress bar between :
           // 0 : external synchro is triggered but there is no needed questionnaire so we want a fullfilled progress bar
           // undefined : external synchro is not triggered so we don't want the progress bar
-          totalExternalResources: externalResourcesUrl ? Infinity : undefined,
+          totalExternalResources: EXTERNAL_RESOURCES_URL ? Infinity : undefined,
           externalResourcesCompleted: 0,
         })
       ),

--- a/drama-queen/src/core/usecases/synchronizeData/thunks.ts
+++ b/drama-queen/src/core/usecases/synchronizeData/thunks.ts
@@ -3,12 +3,12 @@ import { actions, name } from './state'
 import { AxiosError } from 'axios'
 import type { Questionnaire } from 'core/model'
 import {
-  externalResourcesUrl,
   getExternalQuestionnaireFiltered,
   getExternalQuestionnaires,
   getOldExternalCacheNames,
   getResourcesFromExternalQuestionnaire,
 } from 'core/tools/externalResources'
+import { EXTERNAL_RESOURCES_URL } from 'core/constants'
 
 const externalResourcesRootCacheName = 'cache-root-external'
 
@@ -186,7 +186,7 @@ export const thunks = {
          */
 
         // we sychronize the external ressource only if there is a url for getting them
-        if (externalResourcesUrl) {
+        if (EXTERNAL_RESOURCES_URL) {
           // get the list of external questionnaires
           const externalQuestionnaires =
             await getExternalQuestionnaires().catch((error) => {

--- a/drama-queen/src/core/usecases/synchronizeData/thunks.ts
+++ b/drama-queen/src/core/usecases/synchronizeData/thunks.ts
@@ -10,7 +10,7 @@ import {
 } from 'core/tools/externalResources'
 import { EXTERNAL_RESOURCES_URL } from 'core/constants'
 
-const externalResourcesRootCacheName = 'cache-root-external'
+const EXTERNAL_RESOURCES_ROOT_CACHE_NAME = 'cache-root-external'
 
 export const thunks = {
   download:
@@ -242,7 +242,7 @@ export const thunks = {
           // delete the root-cache of external resources if no external questionnaire is needed
           const prDeleteExternalRootCache =
             neededQuestionnaires.length === 0
-              ? caches.delete(externalResourcesRootCacheName)
+              ? caches.delete(EXTERNAL_RESOURCES_ROOT_CACHE_NAME)
               : Promise.resolve()
 
           // delete old caches (that are not in external questionnaires list but sill in browser) :

--- a/drama-queen/src/i18n/resources/en.ts
+++ b/drama-queen/src/i18n/resources/en.ts
@@ -1,5 +1,5 @@
 import type { Translations } from '../types'
-import { lunaticModelVersionBreaking } from 'core/tools/SurveyModelBreaking'
+import { LUNATIC_MODEL_VERSION_BREAKING } from 'core/tools/SurveyModelBreaking'
 
 export const translations: Translations<'en'> = {
   errorMessage: {
@@ -22,7 +22,7 @@ export const translations: Translations<'en'> = {
       `Survey unit ${surveyUnitId} not found.`,
     lunaticModelVersionNotFound:
       'The questionnaire has no lunaticModelVersion field',
-    questionnaireNotCompatible: `The questionnaire is not compatible. The 'lunaticModelVersion' must be higher than ${lunaticModelVersionBreaking}`,
+    questionnaireNotCompatible: `The questionnaire is not compatible. The 'lunaticModelVersion' must be higher than ${LUNATIC_MODEL_VERSION_BREAKING}`,
     questionnaireNotFound: ({ questionnaireId }) =>
       `Unable to retrieve questionnaire ${questionnaireId}.`,
     wrongQuestionnaire: ({ surveyUnitId, questionnaireId }) =>

--- a/drama-queen/src/i18n/resources/en.ts
+++ b/drama-queen/src/i18n/resources/en.ts
@@ -1,5 +1,5 @@
+import { LUNATIC_MODEL_VERSION_BREAKING } from 'core/constants'
 import type { Translations } from '../types'
-import { LUNATIC_MODEL_VERSION_BREAKING } from 'core/tools/SurveyModelBreaking'
 
 export const translations: Translations<'en'> = {
   errorMessage: {

--- a/drama-queen/src/i18n/resources/fr.ts
+++ b/drama-queen/src/i18n/resources/fr.ts
@@ -1,5 +1,5 @@
 import type { Translations } from '../types'
-import { lunaticModelVersionBreaking } from 'core/tools/SurveyModelBreaking'
+import { LUNATIC_MODEL_VERSION_BREAKING } from 'core/tools/SurveyModelBreaking'
 
 export const translations: Translations<'fr'> = {
   errorMessage: {
@@ -23,7 +23,7 @@ export const translations: Translations<'fr'> = {
       `L'unité enquêtée ${surveyUnitId} est introuvable.`,
     lunaticModelVersionNotFound:
       'Le questionnaire ne comporte pas de champ lunaticModelVersion',
-    questionnaireNotCompatible: `Le questionnaire est incompatible. La version du 'lunaticModelVersion' doit être supérieure à  ${lunaticModelVersionBreaking}`,
+    questionnaireNotCompatible: `Le questionnaire est incompatible. La version du 'lunaticModelVersion' doit être supérieure à  ${LUNATIC_MODEL_VERSION_BREAKING}`,
     questionnaireNotFound: ({ questionnaireId }) =>
       `Impossible de récupérer le questionnaire ${questionnaireId}.`,
     wrongQuestionnaire: ({ surveyUnitId, questionnaireId }) =>

--- a/drama-queen/src/i18n/resources/fr.ts
+++ b/drama-queen/src/i18n/resources/fr.ts
@@ -1,5 +1,5 @@
+import { LUNATIC_MODEL_VERSION_BREAKING } from 'core/constants'
 import type { Translations } from '../types'
-import { LUNATIC_MODEL_VERSION_BREAKING } from 'core/tools/SurveyModelBreaking'
 
 export const translations: Translations<'fr'> = {
   errorMessage: {

--- a/drama-queen/src/main.tsx
+++ b/drama-queen/src/main.tsx
@@ -1,3 +1,5 @@
+import { EXTERNAL_RESOURCES_URL } from 'core/constants'
+
 import('./bootstrap').then(({ mount, mountExternalResources }) => {
   const localRoot = document.getElementById('drama-queen')
 
@@ -6,8 +8,7 @@ import('./bootstrap').then(({ mount, mountExternalResources }) => {
     routingStrategy: 'browser',
   })
 
-  if (import.meta.env.VITE_EXTERNAL_RESOURCES_URL)
-    mountExternalResources(import.meta.env.VITE_EXTERNAL_RESOURCES_URL)
+  if (EXTERNAL_RESOURCES_URL) mountExternalResources(EXTERNAL_RESOURCES_URL)
 })
 
 export {}

--- a/drama-queen/src/ui/components/orchestrator/Header/Header.tsx
+++ b/drama-queen/src/ui/components/orchestrator/Header/Header.tsx
@@ -14,7 +14,7 @@ import { BreadCrumb } from '../Breadcrumb/Breadcrumb'
 import { Menu } from '../Menu/Menu'
 import { ShortCut } from '../buttons/ShortCut/ShortCut'
 import type { GoToPage, Overview, OverviewItem } from '../lunaticType'
-import { DYNAMIC_PUBLIC_URL } from 'core'
+import { DYNAMIC_PUBLIC_URL } from 'core/constants'
 
 type HeaderProps = {
   questionnaireTitle: string

--- a/drama-queen/src/ui/components/orchestrator/tools/functions.tsx
+++ b/drama-queen/src/ui/components/orchestrator/tools/functions.tsx
@@ -1,8 +1,7 @@
 import type { PageTag, SurveyUnit, SurveyUnitData } from 'core/model'
 import type { Component, Components } from '../lunaticType'
 import type { LunaticData } from '@inseefr/lunatic'
-
-const externalResourcesUrl = import.meta.env.VITE_EXTERNAL_RESOURCES_URL
+import { EXTERNAL_RESOURCES_URL } from 'core/constants'
 
 /**
  * temporary : should be handle by Lunatic
@@ -89,7 +88,7 @@ function getInitialData(
   questionnaireId: string,
   data?: SurveyUnitData
 ): SurveyUnitData {
-  if (!externalResourcesUrl) return data ?? {}
+  if (!EXTERNAL_RESOURCES_URL) return data ?? {}
   return {
     ...data,
     EXTERNAL: {

--- a/drama-queen/src/ui/components/orchestrator/tools/functions.tsx
+++ b/drama-queen/src/ui/components/orchestrator/tools/functions.tsx
@@ -1,6 +1,5 @@
 import type { PageTag, SurveyUnit, SurveyUnitData } from 'core/model'
 import type { Component, Components } from '../lunaticType'
-import type { LunaticData } from '@inseefr/lunatic'
 import { EXTERNAL_RESOURCES_URL } from 'core/constants'
 
 /**

--- a/drama-queen/src/ui/routing/routes.tsx
+++ b/drama-queen/src/ui/routing/routes.tsx
@@ -13,6 +13,7 @@ import {
 import { Review } from 'ui/pages/review/Review'
 import { ErrorPage } from 'ui/pages/Error/Error'
 import { ExternalRessources } from 'ui/pages/External/External'
+import { EXTERNAL_RESOURCES_URL } from 'core/constants'
 
 const getChildrenRoutes = () => {
   const baseRoutes = [
@@ -48,7 +49,7 @@ const getChildrenRoutes = () => {
     },
   ]
 
-  if (!import.meta.env.VITE_EXTERNAL_RESOURCES_URL) return baseRoutes
+  if (!EXTERNAL_RESOURCES_URL) return baseRoutes
 
   return [
     {

--- a/drama-queen/src/unsubscribe_old_sw.ts
+++ b/drama-queen/src/unsubscribe_old_sw.ts
@@ -1,4 +1,4 @@
-import { DYNAMIC_PUBLIC_URL } from 'core'
+import { DYNAMIC_PUBLIC_URL } from 'core/constants'
 
 // Unregister old service workers for standalone
 export const unsubscribeOldSW = () => {


### PR DESCRIPTION
- create a const for regrouping all the import.meta.env.VITE_EXTERNAL_RESOURCES_URL
- write in uppercase all the consts with a hard-coded value (see https://javascript.info/variables#uppercase-constants)