### PR TITLE
fix: mount external resources

### DIFF
--- a/drama-queen/src/bootstrap.tsx
+++ b/drama-queen/src/bootstrap.tsx
@@ -5,12 +5,20 @@ import { RouterProvider } from 'react-router-dom'
 import { unsubscribeOldSW } from 'unsubscribe_old_sw'
 import { CoreProvider } from 'createCore'
 import { createRouter, type RoutingStrategy } from 'ui/routing/createRouter'
+import { EXTERNAL_RESOURCES_URL } from 'core/constants'
 
 const CenteredSpinner = () => (
   <Stack alignItems="center" justifyContent="center" height="100vh">
     <CircularProgress size={'5em'} />
   </Stack>
 )
+
+const mountExternalResources = (externalResourcesUrl: string) => {
+  console.log('Mount External resources')
+  const script = document.createElement('script')
+  script.src = `${externalResourcesUrl}/entry.js`
+  document.body.appendChild(script)
+}
 
 const mount = ({
   mountPoint,
@@ -26,6 +34,8 @@ const mount = ({
   // unsubscribe to old SW
   unsubscribeOldSW()
 
+  if (EXTERNAL_RESOURCES_URL) mountExternalResources(EXTERNAL_RESOURCES_URL)
+
   const router = createRouter({ strategy: routingStrategy, initialPathname })
   const root = createRoot(mountPoint)
   root.render(
@@ -37,11 +47,4 @@ const mount = ({
   return () => queueMicrotask(() => root.unmount())
 }
 
-const mountExternalResources = (externalResourcesUrl: string) => {
-  console.log('Mount External resources')
-  const script = document.createElement('script')
-  script.src = `${externalResourcesUrl}/entry.js`
-  document.body.appendChild(script)
-}
-
-export { mount, mountExternalResources }
+export { mount }

--- a/drama-queen/src/main.tsx
+++ b/drama-queen/src/main.tsx
@@ -1,14 +1,10 @@
-import { EXTERNAL_RESOURCES_URL } from 'core/constants'
-
-import('./bootstrap').then(({ mount, mountExternalResources }) => {
+import('./bootstrap').then(({ mount }) => {
   const localRoot = document.getElementById('drama-queen')
 
   mount({
     mountPoint: localRoot!,
     routingStrategy: 'browser',
   })
-
-  if (EXTERNAL_RESOURCES_URL) mountExternalResources(EXTERNAL_RESOURCES_URL)
 })
 
 export {}


### PR DESCRIPTION
Entry point for Pearl-Jam is only the `mount` function exported by boostrap.tsx
We don't want to let Pearl-Jam decide if you have to mount externalResources.

So we adapt de `mount` function to load externalResources if needed.

See: 
- Usage in Pearl-Jam: https://github.com/InseeFr/Pearl-Jam/blob/master/src/pages/QueenPage.jsx#L3
- Export in Drama-Queen: https://github.com/InseeFr/Drama-Queen/blob/2.3/drama-queen/vite.config.ts#L34