### PR TITLE
fix: load external app

### DIFF
--- a/drama-queen/src/bootstrap.tsx
+++ b/drama-queen/src/bootstrap.tsx
@@ -13,13 +13,6 @@ const CenteredSpinner = () => (
   </Stack>
 )
 
-const mountExternalResources = (externalResourcesUrl: string) => {
-  console.log('Mount External resources')
-  const script = document.createElement('script')
-  script.src = `${externalResourcesUrl}/entry.js`
-  document.body.appendChild(script)
-}
-
 const mount = ({
   mountPoint,
   initialPathname,
@@ -33,8 +26,6 @@ const mount = ({
 
   // unsubscribe to old SW
   unsubscribeOldSW()
-
-  if (EXTERNAL_RESOURCES_URL) mountExternalResources(EXTERNAL_RESOURCES_URL)
 
   const router = createRouter({ strategy: routingStrategy, initialPathname })
   const root = createRoot(mountPoint)

--- a/drama-queen/src/bootstrap.tsx
+++ b/drama-queen/src/bootstrap.tsx
@@ -1,17 +1,9 @@
-import Stack from '@mui/material/Stack'
-import CircularProgress from '@mui/material/CircularProgress'
 import { createRoot } from 'react-dom/client'
 import { RouterProvider } from 'react-router-dom'
 import { unsubscribeOldSW } from 'unsubscribe_old_sw'
 import { CoreProvider } from 'createCore'
 import { createRouter, type RoutingStrategy } from 'ui/routing/createRouter'
-import { EXTERNAL_RESOURCES_URL } from 'core/constants'
-
-const CenteredSpinner = () => (
-  <Stack alignItems="center" justifyContent="center" height="100vh">
-    <CircularProgress size={'5em'} />
-  </Stack>
-)
+import { CenteredSpinner } from 'ui/components/CenteredSpinner'
 
 const mount = ({
   mountPoint,

--- a/drama-queen/src/i18n/resources/en.ts
+++ b/drama-queen/src/i18n/resources/en.ts
@@ -29,6 +29,7 @@ export const translations: Translations<'en'> = {
       `The survey unit ${surveyUnitId} is not associated with the questionnaire ${questionnaireId}.`,
     surveyUnitUnauthorized:
       'You are not authorized to access data from this survey unit.',
+    externalResourcesLoadedError: 'Unable to load external resources.',
   },
   modalMessage: {
     reviewQuitTitle: 'Leaving the questionnaire',

--- a/drama-queen/src/i18n/resources/fr.ts
+++ b/drama-queen/src/i18n/resources/fr.ts
@@ -30,6 +30,8 @@ export const translations: Translations<'fr'> = {
       `L'unité enquêtée ${surveyUnitId} n'est pas associée au questionnaire ${questionnaireId}.`,
     surveyUnitUnauthorized:
       "Vous n'êtes pas autorisé à accéder aux données de cette unité enquêtée.",
+    externalResourcesLoadedError:
+      'Impossible de charger les ressources externes.',
   },
   modalMessage: {
     reviewQuitTitle: 'Sortie du questionnaire',

--- a/drama-queen/src/i18n/types.ts
+++ b/drama-queen/src/i18n/types.ts
@@ -32,6 +32,7 @@ export type ErrorMessage =
       P: { surveyUnitId: string; questionnaireId: string }
     }
   | 'surveyUnitUnauthorized'
+  | 'externalResourcesLoadedError'
 
 export type ModalMessage =
   | 'reviewQuitTitle'

--- a/drama-queen/src/ui/components/CenteredSpinner.tsx
+++ b/drama-queen/src/ui/components/CenteredSpinner.tsx
@@ -1,0 +1,8 @@
+import CircularProgress from '@mui/material/CircularProgress'
+import Stack from '@mui/material/Stack'
+
+export const CenteredSpinner = () => (
+  <Stack alignItems="center" justifyContent="center" height="100vh">
+    <CircularProgress size={'5em'} />
+  </Stack>
+)

--- a/drama-queen/src/ui/pages/External/External.tsx
+++ b/drama-queen/src/ui/pages/External/External.tsx
@@ -11,5 +11,5 @@ export function ExternalRessources() {
 
   mountExternalResources(EXTERNAL_RESOURCES_URL)
   // Nothing to return, is the loaded script which create html-element.
-  return
+  return null
 }

--- a/drama-queen/src/ui/pages/External/External.tsx
+++ b/drama-queen/src/ui/pages/External/External.tsx
@@ -1,15 +1,18 @@
 import { EXTERNAL_RESOURCES_URL } from 'core/constants'
+import useScript from './useScript'
+import { ErrorComponent } from 'ui/components/ErrorComponent'
+import { CenteredSpinner } from 'ui/components/CenteredSpinner'
+import { getTranslation } from 'i18n'
+
+const { t } = getTranslation('errorMessage')
 
 export function ExternalRessources() {
-  const mountExternalResources = (externalResourcesUrl: string) => {
-    console.log('Mount External resources')
-    const script = document.createElement('script')
-    script.src = `${externalResourcesUrl}/entry.js`
-    script.defer = true // wait
-    document.body.appendChild(script)
-  }
-
-  mountExternalResources(EXTERNAL_RESOURCES_URL)
-  // Nothing to return, is the loaded script which create html-element.
-  return null
+  const status = useScript(`${EXTERNAL_RESOURCES_URL}/entry.js`, {
+    id: 'capmi-app-scripts',
+    removeOnUnmount: true,
+  })
+  if (status === 'loading' || status === 'idle') return <CenteredSpinner />
+  if (status === 'ready') return <capmi-app />
+  if (status === 'error')
+    return <ErrorComponent message={t('externalResourcesLoadedError')} />
 }

--- a/drama-queen/src/ui/pages/External/External.tsx
+++ b/drama-queen/src/ui/pages/External/External.tsx
@@ -1,3 +1,15 @@
+import { EXTERNAL_RESOURCES_URL } from 'core/constants'
+
 export function ExternalRessources() {
-  return <capmi-app />
+  const mountExternalResources = (externalResourcesUrl: string) => {
+    console.log('Mount External resources')
+    const script = document.createElement('script')
+    script.src = `${externalResourcesUrl}/entry.js`
+    script.defer = true // wait
+    document.body.appendChild(script)
+  }
+
+  mountExternalResources(EXTERNAL_RESOURCES_URL)
+  // Nothing to return, is the loaded script which create html-element.
+  return
 }

--- a/drama-queen/src/ui/pages/External/useScript.tsx
+++ b/drama-queen/src/ui/pages/External/useScript.tsx
@@ -1,0 +1,123 @@
+import { useEffect, useState } from 'react'
+
+type UseScriptStatus = 'idle' | 'loading' | 'ready' | 'error'
+
+type UseScriptOptions = {
+  shouldPreventLoad?: boolean
+  removeOnUnmount?: boolean
+  id?: string
+}
+
+// Cached script statuses
+const cachedScriptStatuses = new Map<string, UseScriptStatus | undefined>()
+
+function getScriptNode(src: string) {
+  const node: HTMLScriptElement | null = document.querySelector(
+    `script[src="${src}"]`
+  )
+  const status = node?.getAttribute('data-status') as
+    | UseScriptStatus
+    | undefined
+
+  return {
+    node,
+    status,
+  }
+}
+
+/**
+ * A hook that allows to load scripts asynchronously and track their status.
+ * @param {string | null} src - The URL of the script to load.
+ * @param {UseScriptOptions} options - An object with options for the hook.
+ * @returns {string} A string representing the status of the script.
+ */
+export default function useScript(
+  src: string | null,
+  options?: UseScriptOptions
+): UseScriptStatus {
+  const [status, setStatus] = useState<UseScriptStatus>(() => {
+    if (!src || options?.shouldPreventLoad) {
+      return 'idle'
+    }
+
+    if (typeof window === 'undefined') {
+      // SSR Handling - always return 'loading'
+      return 'loading'
+    }
+
+    return cachedScriptStatuses.get(src) ?? 'loading'
+  })
+
+  useEffect(() => {
+    if (!src || options?.shouldPreventLoad) {
+      return
+    }
+
+    const cachedScriptStatus = cachedScriptStatuses.get(src)
+    if (cachedScriptStatus === 'ready' || cachedScriptStatus === 'error') {
+      // If the script is already cached, set its status immediately
+      setStatus(cachedScriptStatus)
+      return
+    }
+
+    // Fetch existing script element by src
+    // It may have been added by another instance of this hook
+    const script = getScriptNode(src)
+    let scriptNode = script.node
+
+    if (!scriptNode) {
+      // Create script element and add it to document body
+      scriptNode = document.createElement('script')
+      scriptNode.src = src
+      scriptNode.async = true
+      if (options?.id) {
+        scriptNode.id = options.id
+      }
+      scriptNode.setAttribute('data-status', 'loading')
+      document.body.appendChild(scriptNode)
+
+      // Store status in attribute on script
+      // This can be read by other instances of this hook
+      const setAttributeFromEvent = (event: Event) => {
+        const scriptStatus: UseScriptStatus =
+          event.type === 'load' ? 'ready' : 'error'
+
+        scriptNode?.setAttribute('data-status', scriptStatus)
+      }
+
+      scriptNode.addEventListener('load', setAttributeFromEvent)
+      scriptNode.addEventListener('error', setAttributeFromEvent)
+    } else {
+      // Grab existing script status from attribute and set to state.
+      setStatus(script.status ?? cachedScriptStatus ?? 'loading')
+    }
+
+    // Script event handler to update status in state
+    // Note: Even if the script already exists we still need to add
+    // event handlers to update the state for *this* hook instance.
+    const setStateFromEvent = (event: Event) => {
+      const newStatus = event.type === 'load' ? 'ready' : 'error'
+      setStatus(newStatus)
+      cachedScriptStatuses.set(src, newStatus)
+    }
+
+    // Add event listeners
+    scriptNode.addEventListener('load', setStateFromEvent)
+    scriptNode.addEventListener('error', setStateFromEvent)
+
+    // Remove event listeners on cleanup
+    return () => {
+      if (scriptNode) {
+        scriptNode.removeEventListener('load', setStateFromEvent)
+        scriptNode.removeEventListener('error', setStateFromEvent)
+      }
+
+      if (scriptNode && options?.removeOnUnmount) {
+        scriptNode.remove()
+        cachedScriptStatuses.delete(src)
+      }
+    }
+  }, [src, options?.shouldPreventLoad, options?.removeOnUnmount, options?.id])
+
+  return status
+}

--- a/drama-queen/vite.config.ts
+++ b/drama-queen/vite.config.ts
@@ -50,7 +50,7 @@ export default defineConfig({
       // main file is 2.14 MB, and default value is 2.09 MB, so we adjust maximumFileSizeToCacheInBytes to cache all needed files
       // https://vite-pwa-org.netlify.app/guide/faq#missing-assets-from-sw-precache-manifest
       injectManifest: {
-        maximumFileSizeToCacheInBytes: 2500000,
+        maximumFileSizeToCacheInBytes: 4500000,
         // do not minify to avoid variable name conflicts with parent-app
         minify: false,
       },


### PR DESCRIPTION
fix #267 

It's weird, but, loading script only if  `<capmi-app />` has to be load,
`<capmi-app />` is write only if external script is ready