### PR TITLE
fix: unwanted tab close when quitting questionnaire by menu

### DIFF
--- a/src/ui/components/orchestrator/Menu/StopNavigation/StopNavigation.test.tsx
+++ b/src/ui/components/orchestrator/Menu/StopNavigation/StopNavigation.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render } from '@testing-library/react'
+import { act, fireEvent, render } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { TestWrapper } from '@/tests/TestWrapper'
@@ -67,6 +67,21 @@ describe('StopNavigation Component', () => {
       expect.objectContaining({
         label: '2. temporaryQuestionnaireStop',
         onClick: expect.any(Function),
+      }),
+      {},
+    )
+  })
+
+  it('does not open the modal initially', () => {
+    render(
+      <TestWrapper>
+        <StopNavigation {...defaultProps} />
+      </TestWrapper>,
+    )
+
+    expect(Modal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isOpen: false,
       }),
       {},
     )
@@ -150,9 +165,11 @@ describe('StopNavigation Component', () => {
     // Get the modal props from the second render
     const modalProps = vi.mocked(Modal).mock.calls[1][0]
     // Simulate Modal's onClose call
-    modalProps.onClose()
+    act(() => {
+      modalProps.onClose()
+    })
 
-    expect(Modal).toHaveBeenCalledWith(
+    expect(Modal).toHaveBeenLastCalledWith(
       expect.objectContaining({
         isOpen: false,
       }),

--- a/src/ui/components/orchestrator/Menu/StopNavigation/StopNavigation.test.tsx
+++ b/src/ui/components/orchestrator/Menu/StopNavigation/StopNavigation.test.tsx
@@ -159,4 +159,48 @@ describe('StopNavigation Component', () => {
       {},
     )
   })
+
+  it('calls definitiveQuit function when validate button is clicked in the modal', () => {
+    const { getByRole } = render(
+      <TestWrapper>
+        <StopNavigation {...defaultProps} />
+      </TestWrapper>,
+    )
+
+    // Open the definitive quit modal
+    const definitivequitButton = getByRole('button', {
+      name: '1. definitiveQuestionnaireStop',
+    })
+    fireEvent.click(definitivequitButton)
+
+    // Get the modal props from the second render
+    const modalProps = vi.mocked(Modal).mock.calls[1][0]
+    // Simulate Modal's validate button onClick call
+    modalProps.buttons[1].onClick()
+
+    expect(mockDefinitiveQuit).toHaveBeenCalledOnce()
+    expect(mockQuit).not.toHaveBeenCalled()
+  })
+
+  it('calls quit function when validate button is clicked in the modal', () => {
+    const { getByRole } = render(
+      <TestWrapper>
+        <StopNavigation {...defaultProps} />
+      </TestWrapper>,
+    )
+
+    // Click on the temporary quit button
+    const temporaryQuitButton = getByRole('button', {
+      name: '2. temporaryQuestionnaireStop',
+    })
+    fireEvent.click(temporaryQuitButton)
+
+    // Get the modal props from the second render
+    const modalProps = vi.mocked(Modal).mock.calls[1][0]
+    // Simulate Modal's validate button onClick call
+    modalProps.buttons[1].onClick()
+
+    expect(mockQuit).toHaveBeenCalledOnce()
+    expect(mockDefinitiveQuit).not.toHaveBeenCalled()
+  })
 })

--- a/src/ui/components/orchestrator/Menu/StopNavigation/StopNavigation.tsx
+++ b/src/ui/components/orchestrator/Menu/StopNavigation/StopNavigation.tsx
@@ -55,12 +55,7 @@ export function StopNavigation(props: StopNavigationProps) {
 
   const quitModalOnClose = () => setIsQuitOpenModal(false)
 
-  const quitModalValidate = () => {
-    if (isDefinitiveModal) {
-      definitiveQuit()
-    } else quit()
-    close()
-  }
+  const quitModalValidateOnClick = isDefinitiveModal ? definitiveQuit : quit
 
   const quitModalButtons = [
     {
@@ -70,7 +65,7 @@ export function StopNavigation(props: StopNavigationProps) {
     },
     {
       label: quitModalValidateLabel,
-      onClick: quitModalValidate,
+      onClick: quitModalValidateOnClick,
       autoFocus: true,
     },
   ]


### PR DESCRIPTION
remove the unwanted window.close() when leaving questionnaire by the menu