### PR TITLE
feat: enable loop panel navigation to any iteration

### DIFF
--- a/src/ui/components/orchestrator/LoopPanel/LoopPanel.test.tsx
+++ b/src/ui/components/orchestrator/LoopPanel/LoopPanel.test.tsx
@@ -1,16 +1,11 @@
 import { fireEvent, render } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 
-import type { PageTag, SurveyUnitData } from '@/core/model'
+import type { SurveyUnitData } from '@/core/model'
 
-import { isIterationReachable } from '../tools/functions'
 import { LoopPanel } from './LoopPanel'
 
 const mockGoToPage = vi.fn()
-
-vi.mock('@/ui/components/orchestrator/tools/functions', () => ({
-  isIterationReachable: vi.fn(),
-}))
 
 describe('LoopPanel Component', () => {
   const mockLoopVariables = ['loopTitle']
@@ -21,14 +16,12 @@ describe('LoopPanel Component', () => {
       },
     },
   }
-  const mockLastReachedPage: PageTag = '2'
 
   const defaultProps = {
     loopVariables: mockLoopVariables,
     page: 1,
     subPage: undefined,
     iteration: undefined,
-    lastReachedPage: mockLastReachedPage,
     data: mockData,
     goToPage: mockGoToPage,
   }
@@ -44,23 +37,7 @@ describe('LoopPanel Component', () => {
     expect(getByText('Iteration 3')).toBeInTheDocument()
   })
 
-  it('disables buttons for unreachable iterations', () => {
-    // we mock the isIterationReachable function : every iteration is reachable except iteration 1
-    vi.mocked(isIterationReachable).mockImplementation(
-      (_page, _lastReachedPage, iteration) => iteration !== 1,
-    )
-
-    const { getAllByRole } = render(<LoopPanel {...defaultProps} />)
-
-    const buttons = getAllByRole('button')
-
-    // considering isIterationReachable mock : only button for iteration 1 is disabled
-    expect(buttons[0]).not.toBeDisabled()
-    expect(buttons[1]).toBeDisabled()
-    expect(buttons[2]).not.toBeDisabled()
-  })
-
-  it('go to the page {page, subPage:0} page on button click', () => {
+  it('goes to the page {page, subPage:0} page on button click', () => {
     const { getAllByRole } = render(<LoopPanel {...defaultProps} />)
 
     const buttons = getAllByRole('button')
@@ -82,6 +59,16 @@ describe('LoopPanel Component', () => {
     })
   })
 
+  it('enables to navigate to any iteration', () => {
+    const { getAllByRole } = render(<LoopPanel {...defaultProps} />)
+
+    const buttons = getAllByRole('button')
+
+    expect(buttons[0]).not.toBeDisabled()
+    expect(buttons[1]).not.toBeDisabled()
+    expect(buttons[2]).not.toBeDisabled()
+  })
+
   it('applies different styles for current and non-current iterations', () => {
     const props = { ...defaultProps, iteration: 1 }
 
@@ -95,13 +82,6 @@ describe('LoopPanel Component', () => {
 
   it('returns null if loopVariables is empty (we are not in a loop)', () => {
     const props = { ...defaultProps, loopVariables: [] }
-
-    const { container } = render(<LoopPanel {...props} />)
-    expect(container.firstChild).toBeNull()
-  })
-
-  it('returns null if lastReachedPage is undefined', () => {
-    const props = { ...defaultProps, lastReachedPage: undefined }
 
     const { container } = render(<LoopPanel {...props} />)
     expect(container.firstChild).toBeNull()

--- a/src/ui/components/orchestrator/LoopPanel/LoopPanel.tsx
+++ b/src/ui/components/orchestrator/LoopPanel/LoopPanel.tsx
@@ -5,25 +5,22 @@ import Stack from '@mui/material/Stack'
 import Typography from '@mui/material/Typography'
 import { tss } from 'tss-react/mui'
 
-import type { PageTag, SurveyUnitData } from '@/core/model'
-import { isIterationReachable } from '@/ui/components/orchestrator/tools/functions'
+import type { SurveyUnitData } from '@/core/model'
 
 type LoopPanelProps = {
   loopVariables: string[]
   page: number
   subPage: number | undefined
   iteration: number | undefined
-  lastReachedPage: PageTag | undefined
   data: SurveyUnitData
   goToPage: ReturnType<typeof useLunatic>['goToPage']
 }
 
 export function LoopPanel(props: LoopPanelProps) {
-  const { loopVariables, page, iteration, lastReachedPage, data, goToPage } =
-    props
+  const { loopVariables, page, iteration, data, goToPage } = props
   const { classes, cx } = useStyles()
 
-  if (!loopVariables[0] || !lastReachedPage || !data.COLLECTED) {
+  if (!loopVariables[0] || !data.COLLECTED) {
     return null
   }
 
@@ -36,10 +33,6 @@ export function LoopPanel(props: LoopPanelProps) {
   if (!titleData) {
     return null
   }
-
-  // panel is disabled if you cannot reach the first subPage of the iteration
-  const isDisabledButton = (iteration: number) =>
-    !isIterationReachable(page, lastReachedPage, iteration)
 
   // redirects to the first subPage of an iteration (in the same loop so "page" does not change)
   const goToIteration = (index: number) => () =>
@@ -56,7 +49,6 @@ export function LoopPanel(props: LoopPanelProps) {
               ? classes.currentIteration
               : classes.notCurrentIteration,
           )}
-          disabled={isDisabledButton(index)}
           disableRipple
           endIcon={<ChevronRightIcon />}
           onClick={goToIteration(index)}

--- a/src/ui/components/orchestrator/Orchestrator.tsx
+++ b/src/ui/components/orchestrator/Orchestrator.tsx
@@ -190,7 +190,6 @@ export function Orchestrator(props: OrchestratorProps) {
               page={page}
               subPage={subPage}
               iteration={iteration}
-              lastReachedPage={lastReachedPage}
               data={surveyUnitData}
               goToPage={goToPage}
             />

--- a/src/ui/components/orchestrator/tools/functions.tsx
+++ b/src/ui/components/orchestrator/tools/functions.tsx
@@ -1,12 +1,7 @@
 import type { Variable } from '@inseefr/lunatic/type.source'
 
 import { EXTERNAL_RESOURCES_URL } from '@/core/constants'
-import type {
-  PageTag,
-  Questionnaire,
-  SurveyUnit,
-  SurveyUnitData,
-} from '@/core/model'
+import type { Questionnaire, SurveyUnit, SurveyUnitData } from '@/core/model'
 
 import type { Component, Components } from '../lunaticType'
 
@@ -81,26 +76,6 @@ export function shouldAutoNext(
           firstComponent.componentType,
         )))
   ) {
-    return true
-  }
-  return false
-}
-
-// check if the first subPage of an iteration is before lastReachedPage
-export function isIterationReachable(
-  currentPage: number,
-  lastReachedPage: PageTag,
-  iteration: number,
-) {
-  const maxPage = parseInt(lastReachedPage.split('.')[0])
-  const maxIteration = parseInt(lastReachedPage.split('#')[1]) - 1
-  if (currentPage < maxPage) {
-    // no need to check iteration or subPage because we already reached the next page (out of the loop)
-    return true
-  }
-  // currentPage = maxPage , so we check if we already reached the iteration
-  if (iteration <= maxIteration) {
-    // no need to check subPage beacause we just want to reach the first subPage of the iteration
     return true
   }
   return false


### PR DESCRIPTION
When you're in a loop, there is a panel displaying every iteration of the loop.
For every iteration, you can click on its button to navigate to its first page.

Currently, as for the rest of the application, we do not enable to navigate further, so we disable iterations that are further lastReachedPage.
We change this principle, to enable to navigate to any iteration while you're in the loop.