### PR TITLE
feat: questionnaire progess bar

### DIFF
--- a/src/ui/components/orchestrator/NavBar/NavBar.test.tsx
+++ b/src/ui/components/orchestrator/NavBar/NavBar.test.tsx
@@ -2,10 +2,16 @@ import { render } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 
 import { PrevNext } from '../buttons/PrevNext/PrevNext'
+import type { Overview } from '../lunaticType'
 import { NavBar } from './NavBar'
+import { StepProgressBar } from './StepProgressBar'
 
 vi.mock('@/i18n', () => ({
   useTranslation: () => ({ t: (keyMessage: string) => keyMessage }),
+}))
+
+vi.mock('./StepProgressBar', () => ({
+  StepProgressBar: vi.fn(),
 }))
 
 vi.mock('../buttons/PrevNext/PrevNext', () => ({
@@ -13,7 +19,41 @@ vi.mock('../buttons/PrevNext/PrevNext', () => ({
 }))
 
 describe('NavBar Component', () => {
+  const defaultOverview: Overview = [
+    {
+      id: 'seq-1',
+      type: 'sequence',
+      page: '1',
+      label: 'Sequence 1',
+      description: 'Description 1',
+      reached: true,
+      current: false,
+      children: [],
+    },
+    {
+      id: 'seq-2',
+      type: 'sequence',
+      page: '2',
+      label: 'Sequence 1',
+      description: 'Description 2',
+      reached: true,
+      current: true,
+      children: [],
+    },
+    {
+      id: 'seq-3',
+      type: 'sequence',
+      page: '3',
+      label: 'Sequence 3',
+      description: 'Description 3',
+      reached: true,
+      current: false,
+      children: [],
+    },
+  ]
+
   const defaultProps = {
+    overview: defaultOverview,
     page: 2,
     maxPage: 5,
     subPage: 1,
@@ -23,6 +63,18 @@ describe('NavBar Component', () => {
     onPrevious: vi.fn(),
     onNext: vi.fn(),
   }
+
+  it('renders StepProgressBar with correct props', () => {
+    render(<NavBar {...defaultProps} />)
+
+    expect(StepProgressBar).toHaveBeenCalledWith(
+      {
+        currentStep: 2, // index of the current sequence + 1 in the overview
+        maxStep: 3, // number of sequences in the overview
+      },
+      {},
+    )
+  })
 
   it('displays correctly the page and subPage count', () => {
     const { getAllByText, getByText } = render(<NavBar {...defaultProps} />)
@@ -37,13 +89,13 @@ describe('NavBar Component', () => {
     expect(getByText('2/3')).toBeInTheDocument()
   })
 
-  it('only displays page information if subPage is undefined', () => {
+  it('hides the subPage information if subPage is undefined', () => {
     const props = { ...defaultProps, subPage: undefined, nbSubPages: undefined }
 
-    const { getAllByText, getByText } = render(<NavBar {...props} />)
-
-    expect(getAllByText('pageNumber')).toHaveLength(1)
-    expect(getByText('2/5')).toBeInTheDocument()
+    const { container } = render(<NavBar {...props} />)
+    const subPageStack = container.querySelector('#progress-subPage')
+    expect(subPageStack).toBeInTheDocument()
+    expect(subPageStack).toHaveStyle('visibility: hidden')
   })
 
   it('renders PrevNext component with the correct props', () => {

--- a/src/ui/components/orchestrator/NavBar/NavBar.test.tsx
+++ b/src/ui/components/orchestrator/NavBar/NavBar.test.tsx
@@ -4,14 +4,15 @@ import { describe, expect, it, vi } from 'vitest'
 import { PrevNext } from '../buttons/PrevNext/PrevNext'
 import type { Overview } from '../lunaticType'
 import { NavBar } from './NavBar'
+import { PageCount } from './PageCount'
 import { StepProgressBar } from './StepProgressBar'
-
-vi.mock('@/i18n', () => ({
-  useTranslation: () => ({ t: (keyMessage: string) => keyMessage }),
-}))
 
 vi.mock('./StepProgressBar', () => ({
   StepProgressBar: vi.fn(),
+}))
+
+vi.mock('./PageCount', () => ({
+  PageCount: vi.fn(),
 }))
 
 vi.mock('../buttons/PrevNext/PrevNext', () => ({
@@ -76,26 +77,38 @@ describe('NavBar Component', () => {
     )
   })
 
-  it('displays correctly the page and subPage count', () => {
-    const { getAllByText, getByText } = render(<NavBar {...defaultProps} />)
+  it('renders PageCount component for both page and subPage with the correct props', () => {
+    const { rerender } = render(<NavBar {...defaultProps} />)
 
-    // pageNumber is displayed twice : for page and for subPage
-    expect(getAllByText('pageNumber')).toHaveLength(2)
+    // subPage count
+    expect(PageCount).toHaveBeenCalledWith(
+      {
+        currentPage: defaultProps.subPage + 1,
+        maxPage: defaultProps.nbSubPages,
+      },
+      {},
+    )
 
-    // page count : `${page}/${maxPage}`
-    expect(getByText('2/5')).toBeInTheDocument()
+    // page count
+    expect(PageCount).toHaveBeenCalledWith(
+      {
+        currentPage: defaultProps.subPage + 1,
+        maxPage: defaultProps.nbSubPages,
+      },
+      {},
+    )
 
-    // subPage count : subPage is an index starting at 0, we display ${subPage}+1
-    expect(getByText('2/3')).toBeInTheDocument()
-  })
+    // subPage count if subPage is undefined
+    const propsWithoutSubPage = { ...defaultProps, subPage: undefined }
+    rerender(<NavBar {...propsWithoutSubPage} />)
 
-  it('hides the subPage information if subPage is undefined', () => {
-    const props = { ...defaultProps, subPage: undefined, nbSubPages: undefined }
-
-    const { container } = render(<NavBar {...props} />)
-    const subPageStack = container.querySelector('#progress-subPage')
-    expect(subPageStack).toBeInTheDocument()
-    expect(subPageStack).toHaveStyle('visibility: hidden')
+    expect(PageCount).toHaveBeenCalledWith(
+      {
+        currentPage: undefined,
+        maxPage: defaultProps.nbSubPages,
+      },
+      {},
+    )
   })
 
   it('renders PrevNext component with the correct props', () => {

--- a/src/ui/components/orchestrator/NavBar/NavBar.tsx
+++ b/src/ui/components/orchestrator/NavBar/NavBar.tsx
@@ -5,8 +5,11 @@ import { tss } from 'tss-react/mui'
 import { useTranslation } from '@/i18n'
 
 import { PrevNext } from '../buttons/PrevNext/PrevNext'
+import type { Overview } from '../lunaticType'
+import { StepProgressBar } from './StepProgressBar'
 
 type NavBarProps = {
+  overview: Overview
   page: number
   maxPage: number
   subPage: number | undefined
@@ -17,8 +20,9 @@ type NavBarProps = {
   onNext: () => void
 }
 
-export function NavBar(props: NavBarProps) {
+export function NavBar(props: Readonly<NavBarProps>) {
   const {
+    overview,
     page,
     maxPage,
     subPage,
@@ -31,39 +35,58 @@ export function NavBar(props: NavBarProps) {
   const { classes } = useStyles()
   const { t } = useTranslation('navigationMessage')
 
+  const currentSequenceIndex = overview.findIndex(
+    (sequence) => sequence.current,
+  )
+
+  const nbMaxSequence = overview.length
+
+  type PageType = 'page' | 'subPage'
+
   const displayPages = [
     {
+      type: 'subPage' as PageType,
       current: subPage === undefined ? subPage : subPage + 1,
       max: nbSubPages,
     },
     {
+      type: 'page' as PageType,
       current: page,
       max: maxPage,
     },
   ]
 
-  function displayPage(
-    pageType: {
-      current: number | undefined
-      max: number | undefined
-    },
-    index: number,
-  ) {
-    if (pageType.current !== undefined) {
-      return (
-        <Stack className={classes.page} key={`displayPages-${index}`}>
-          <Typography variant="caption">{t('pageNumber')}</Typography>
-          <Typography variant="body2" fontWeight={'bold'}>
-            {pageType.current}/{pageType.max}
-          </Typography>
-        </Stack>
-      )
-    }
+  function displayPage(pageType: {
+    type: PageType
+    current: number | undefined
+    max: number | undefined
+  }) {
+    return (
+      <Stack
+        className={classes.page}
+        key={`progress-${pageType.type}`}
+        id={`progress-${pageType.type}`}
+        style={{
+          visibility: pageType.current === undefined ? 'hidden' : 'visible',
+        }}
+      >
+        <Typography variant="caption">{t('pageNumber')}</Typography>
+        <Typography variant="body2" fontWeight={'bold'}>
+          {pageType.current}/{pageType.max}
+        </Typography>
+      </Stack>
+    )
   }
 
   return (
     <Stack className={classes.root}>
-      {displayPages.map((pageType, index) => displayPage(pageType, index))}
+      <Stack className={classes.progressBar}>
+        <StepProgressBar
+          currentStep={currentSequenceIndex + 1}
+          maxStep={nbMaxSequence}
+        />
+      </Stack>
+      {displayPages.map((pageType) => displayPage(pageType))}
       <PrevNext
         isPreviousEnabled={isPreviousEnabled}
         isNextEnabled={isNextEnabled}
@@ -79,11 +102,20 @@ const useStyles = tss.create(() => ({
     gap: '2em',
     alignItems: 'center',
     width: '60px',
+    height: '100%',
+    marginTop: '2em',
   },
   page: {
     textAlign: 'center',
     borderRadius: '5px',
     width: '57px',
     backgroundColor: 'white',
+  },
+  progressBar: {
+    display: 'flex',
+    flexGrow: 1,
+    '@media (max-height: 500px)': {
+      display: 'none',
+    },
   },
 }))

--- a/src/ui/components/orchestrator/NavBar/NavBar.tsx
+++ b/src/ui/components/orchestrator/NavBar/NavBar.tsx
@@ -1,11 +1,9 @@
 import Stack from '@mui/material/Stack'
-import Typography from '@mui/material/Typography'
 import { tss } from 'tss-react/mui'
-
-import { useTranslation } from '@/i18n'
 
 import { PrevNext } from '../buttons/PrevNext/PrevNext'
 import type { Overview } from '../lunaticType'
+import { PageCount } from './PageCount'
 import { StepProgressBar } from './StepProgressBar'
 
 type NavBarProps = {
@@ -33,7 +31,6 @@ export function NavBar(props: Readonly<NavBarProps>) {
     onNext,
   } = props
   const { classes } = useStyles()
-  const { t } = useTranslation('navigationMessage')
 
   const currentSequenceIndex = overview.findIndex(
     (sequence) => sequence.current,
@@ -41,42 +38,7 @@ export function NavBar(props: Readonly<NavBarProps>) {
 
   const nbMaxSequence = overview.length
 
-  type PageType = 'page' | 'subPage'
-
-  const displayPages = [
-    {
-      type: 'subPage' as PageType,
-      current: subPage === undefined ? subPage : subPage + 1,
-      max: nbSubPages,
-    },
-    {
-      type: 'page' as PageType,
-      current: page,
-      max: maxPage,
-    },
-  ]
-
-  function displayPage(pageType: {
-    type: PageType
-    current: number | undefined
-    max: number | undefined
-  }) {
-    return (
-      <Stack
-        className={classes.page}
-        key={`progress-${pageType.type}`}
-        id={`progress-${pageType.type}`}
-        style={{
-          visibility: pageType.current === undefined ? 'hidden' : 'visible',
-        }}
-      >
-        <Typography variant="caption">{t('pageNumber')}</Typography>
-        <Typography variant="body2" fontWeight={'bold'}>
-          {pageType.current}/{pageType.max}
-        </Typography>
-      </Stack>
-    )
-  }
+  const currentSubPage = subPage === undefined ? subPage : subPage + 1
 
   return (
     <Stack className={classes.root}>
@@ -86,7 +48,8 @@ export function NavBar(props: Readonly<NavBarProps>) {
           maxStep={nbMaxSequence}
         />
       </Stack>
-      {displayPages.map((pageType) => displayPage(pageType))}
+      <PageCount currentPage={currentSubPage} maxPage={nbSubPages} />
+      <PageCount currentPage={page} maxPage={maxPage} />
       <PrevNext
         isPreviousEnabled={isPreviousEnabled}
         isNextEnabled={isNextEnabled}
@@ -104,12 +67,6 @@ const useStyles = tss.create(() => ({
     width: '60px',
     height: '100%',
     marginTop: '2em',
-  },
-  page: {
-    textAlign: 'center',
-    borderRadius: '5px',
-    width: '57px',
-    backgroundColor: 'white',
   },
   progressBar: {
     display: 'flex',

--- a/src/ui/components/orchestrator/NavBar/PageCount.test.tsx
+++ b/src/ui/components/orchestrator/NavBar/PageCount.test.tsx
@@ -1,0 +1,30 @@
+import { render } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { PageCount } from './PageCount'
+
+vi.mock('@/i18n', () => ({
+  useTranslation: () => ({ t: (keyMessage: string) => keyMessage }),
+}))
+
+describe('NavBar Component', () => {
+  it('displays correctly the page and subPage count', () => {
+    const { getByText } = render(<PageCount currentPage={2} maxPage={5} />)
+
+    // pageNumber is displayed twice : for page and for subPage
+    expect(getByText('pageNumber')).toBeInTheDocument()
+
+    // page count : `${page}/${maxPage}`
+    expect(getByText('2/5')).toBeInTheDocument()
+  })
+
+  it('hides the page count if currentPage is undefined', () => {
+    const { container } = render(
+      <PageCount currentPage={undefined} maxPage={5} />,
+    )
+
+    const pageCount = container.querySelector('#page-count')
+    expect(pageCount).toBeInTheDocument()
+    expect(pageCount).toHaveStyle('visibility: hidden')
+  })
+})

--- a/src/ui/components/orchestrator/NavBar/PageCount.tsx
+++ b/src/ui/components/orchestrator/NavBar/PageCount.tsx
@@ -1,0 +1,39 @@
+import { Stack, Typography } from '@mui/material'
+import { tss } from 'tss-react/mui'
+
+import { useTranslation } from '@/i18n'
+
+type PageCountProps = {
+  currentPage: number | undefined
+  maxPage: number | undefined
+}
+
+export function PageCount(props: Readonly<PageCountProps>) {
+  const { currentPage, maxPage } = props
+  const { classes } = useStyles()
+  const { t } = useTranslation('navigationMessage')
+
+  return (
+    <Stack
+      className={classes.pageCount}
+      id={`page-count`}
+      style={{
+        visibility: currentPage === undefined ? 'hidden' : 'visible',
+      }}
+    >
+      <Typography variant="caption">{t('pageNumber')}</Typography>
+      <Typography variant="body2" fontWeight={'bold'}>
+        {currentPage}/{maxPage}
+      </Typography>
+    </Stack>
+  )
+}
+
+const useStyles = tss.create(() => ({
+  pageCount: {
+    textAlign: 'center',
+    borderRadius: '5px',
+    width: '57px',
+    backgroundColor: 'white',
+  },
+}))

--- a/src/ui/components/orchestrator/NavBar/StepProgressBar.test.tsx
+++ b/src/ui/components/orchestrator/NavBar/StepProgressBar.test.tsx
@@ -1,0 +1,39 @@
+import { render } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { StepProgressBar } from './StepProgressBar'
+
+describe('StepProgressBar', () => {
+  const defaultProps = { currentStep: 3, maxStep: 5 }
+
+  it('renders the correct number of steps', () => {
+    const { container } = render(<StepProgressBar {...defaultProps} />)
+
+    // Check that there are 5 steps rendered in total
+    const steps = [...Array(5)].map((_, index) =>
+      container.querySelector(`#step-${index}`),
+    )
+
+    // Check all 5 steps are in the document
+    steps.forEach((step) => {
+      expect(step).toBeInTheDocument()
+    })
+  })
+
+  it('marks as active all steps <= currentStep', () => {
+    const { container } = render(<StepProgressBar {...defaultProps} />)
+
+    const steps = [...Array(5)].map((_, index) =>
+      container.querySelector(`#step-${index}`),
+    )
+
+    // Check that the first three steps are marked as active
+    steps.forEach((step, index) => {
+      if (index < 3) {
+        expect(step).toHaveClass(/active/) // cannot check 'active' directly since tss-react generates dynamic class name with prefix
+      } else {
+        expect(step).not.toHaveClass(/active/)
+      }
+    })
+  })
+})

--- a/src/ui/components/orchestrator/NavBar/StepProgressBar.tsx
+++ b/src/ui/components/orchestrator/NavBar/StepProgressBar.tsx
@@ -1,0 +1,48 @@
+import { Stack } from '@mui/material'
+import Box from '@mui/material/Box'
+import { tss } from 'tss-react/mui'
+
+type StepProgressBarProps = {
+  currentStep: number
+  maxStep: number
+}
+
+export function StepProgressBar(props: Readonly<StepProgressBarProps>) {
+  const { currentStep, maxStep } = props
+  const { classes, cx } = useStyles()
+
+  const stepBar = (index: number) => (
+    <Box
+      key={`step-${index}`}
+      id={`step-${index}`}
+      className={cx(classes.step, index < currentStep && classes.active)}
+    />
+  )
+
+  return (
+    <Stack className={classes.container}>
+      {[...Array(maxStep)].map((_, index) => stepBar(index))}
+    </Stack>
+  )
+}
+
+const useStyles = tss.create(() => ({
+  container: {
+    display: 'flex',
+    flexDirection: 'column',
+    height: '100%',
+    gap: '3px',
+    padding: '18px',
+    borderRadius: '5px',
+    backgroundColor: 'white',
+  },
+  step: {
+    flex: 1,
+    width: '7px',
+    backgroundColor: '#B8B8B8',
+    transition: 'background-color 0.3s ease',
+  },
+  active: {
+    backgroundColor: '#666666',
+  },
+}))

--- a/src/ui/components/orchestrator/Orchestrator.tsx
+++ b/src/ui/components/orchestrator/Orchestrator.tsx
@@ -200,6 +200,7 @@ export function Orchestrator(props: OrchestratorProps) {
         </Stack>
         <Stack className={classes.navBarContainer}>
           <NavBar
+            overview={overview}
             page={page}
             maxPage={maxPage}
             subPage={subPage}


### PR DESCRIPTION
In the navigation bar on the right of the orchestrator, add a progress bar : it displays the current sequence compared to the number of sequences.

Example when being on sequence 2/5 :
![tesst](https://github.com/user-attachments/assets/ae0ed50e-1a41-4e0b-a383-09b57f728a83)


I also updated the display of page progress because i wanted the progress bar to take the available space, and needed to always take into account the space used when we display the number of subPages in a loop)
