### PR TITLE
feat: fullscreen mode on orchestrator

### DIFF
--- a/src/i18n/resources/en.ts
+++ b/src/i18n/resources/en.ts
@@ -72,6 +72,8 @@ export const translations: Translations<'en'> = {
     continue: 'Continue',
     dontKnowButtonLabel: "Don't know",
     shortCutNextLabel: 'alt + ENTER',
+    goFullscreen: 'Go fullscreen',
+    exitFullscreen: 'Exit fullscreen',
   },
   synchronizeMessage: {
     synchronizationInProgress: 'Synchronization in progress',

--- a/src/i18n/resources/fr.ts
+++ b/src/i18n/resources/fr.ts
@@ -74,6 +74,8 @@ export const translations: Translations<'fr'> = {
     continue: 'Continuer',
     dontKnowButtonLabel: 'Ne sait pas',
     shortCutNextLabel: 'alt + ENTRÉE',
+    goFullscreen: 'Plein écran',
+    exitFullscreen: 'Quitter le mode plein écran',
   },
   synchronizeMessage: {
     synchronizationInProgress: 'Synchronisation en cours',

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -71,6 +71,8 @@ export type NavigationMessage =
   | 'continue'
   | 'dontKnowButtonLabel'
   | 'shortCutNextLabel'
+  | 'goFullscreen'
+  | 'exitFullscreen'
 
 export type SynchronizeMessage =
   | 'synchronizationInProgress'

--- a/src/ui/components/orchestrator/Header/Header.test.tsx
+++ b/src/ui/components/orchestrator/Header/Header.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render } from '@testing-library/react'
+import { act, fireEvent, render } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 
 import { TestWrapper } from '@/tests/TestWrapper'
@@ -24,6 +24,16 @@ vi.mock('../buttons/ShortCut/ShortCut', () => ({
 
 vi.mock('@/i18n', () => ({
   useTranslation: () => ({ t: (keyMessage: string) => keyMessage }),
+}))
+
+vi.mock('@mui/icons-material/OpenInFull', () => ({
+  __esModule: true,
+  default: vi.fn(() => <svg>OpenInFullIcon</svg>),
+}))
+
+vi.mock('@mui/icons-material/CloseFullscreen', () => ({
+  __esModule: true,
+  default: vi.fn(() => <svg>CloseFullscreenIcon</svg>),
 }))
 
 describe('Header Component', () => {
@@ -62,6 +72,7 @@ describe('Header Component', () => {
 
     expect(getByText('Test Questionnaire')).toBeInTheDocument()
     expect(getByTitle('backToQuestionnaireStart')).toBeInTheDocument()
+    expect(getByTitle('goFullscreen')).toBeInTheDocument()
     expect(getByTitle('quit')).toBeInTheDocument()
   })
 
@@ -92,6 +103,36 @@ describe('Header Component', () => {
     // Close menu
     fireEvent.click(menuButton)
     expect(queryByRole('presentation')).not.toBeInTheDocument()
+  })
+
+  it('should handle fullscreen correctly', async () => {
+    const { container, getByText } = render(
+      <TestWrapper>
+        <Header {...defaultProps} />
+      </TestWrapper>,
+    )
+
+    const fullscreenButton = container.querySelector('#fullscreen')!
+
+    // Should be in non-fullscreen
+    expect(fullscreenButton).toHaveAttribute('title', 'goFullscreen')
+    expect(getByText('OpenInFullIcon')).toBeInTheDocument()
+
+    await act(async () => {
+      fireEvent.click(fullscreenButton)
+    })
+
+    // The title and icon should change
+    expect(fullscreenButton).toHaveAttribute('title', 'exitFullscreen')
+    expect(getByText('CloseFullscreenIcon')).toBeInTheDocument()
+
+    await act(async () => {
+      fireEvent.click(fullscreenButton)
+    })
+
+    // After clicking again, the title and icon should change back
+    expect(fullscreenButton).toHaveAttribute('title', 'goFullscreen')
+    expect(getByText('OpenInFullIcon')).toBeInTheDocument()
   })
 
   it('calls quit when the quit button is clicked', () => {

--- a/src/ui/components/orchestrator/Header/Header.tsx
+++ b/src/ui/components/orchestrator/Header/Header.tsx
@@ -1,5 +1,7 @@
 import AppsIcon from '@mui/icons-material/Apps'
+import CloseFullscreenIcon from '@mui/icons-material/CloseFullscreen'
 import ExitToAppIcon from '@mui/icons-material/ExitToApp'
+import OpenInFullIcon from '@mui/icons-material/OpenInFull'
 import AppBar from '@mui/material/AppBar'
 import Button from '@mui/material/Button'
 import IconButton from '@mui/material/IconButton'
@@ -18,6 +20,7 @@ import { Breadcrumb } from '../Breadcrumb/Breadcrumb'
 import { Menu } from '../Menu/Menu'
 import { ShortCut } from '../buttons/ShortCut/ShortCut'
 import type { GoToPage, Overview, OverviewItem } from '../lunaticType'
+import { useFullscreen } from '../tools/useFullscreen'
 
 type HeaderProps = {
   questionnaireTitle: string
@@ -38,6 +41,7 @@ export function Header(props: HeaderProps) {
     definitiveQuit,
   } = props
   const [isDrawerOpen, setIsDrawerOpen] = useState<boolean>(false)
+  const { isFullscreen, toggleFullscreen } = useFullscreen()
   const { classes } = useStyles({ isDrawerOpen })
   const { t } = useTranslation('navigationMessage')
 
@@ -106,15 +110,21 @@ export function Header(props: HeaderProps) {
           goToPage={goToPage}
         />
       </Stack>
-      <Stack className={classes.headerClose}>
+      <Stack className={classes.rightButtons}>
         <IconButton
-          title={t('quit')}
-          className={classes.closeIcon}
-          onClick={quit}
+          title={isFullscreen ? t('exitFullscreen') : t('goFullscreen')}
+          id="fullscreen"
+          className={classes.fullscreenIcon}
+          onClick={toggleFullscreen}
         >
-          <ExitToAppIcon />
-          <ShortCut shortCutKey={quitShortKey} onClickMethod={quit} />
+          {isFullscreen ? <CloseFullscreenIcon /> : <OpenInFullIcon />}
         </IconButton>
+        <Stack className={classes.headerClose}>
+          <IconButton title={t('quit')} onClick={quit}>
+            <ExitToAppIcon />
+            <ShortCut shortCutKey={quitShortKey} onClickMethod={quit} />
+          </IconButton>
+        </Stack>
       </Stack>
     </AppBar>
   )
@@ -139,12 +149,25 @@ const useStyles = tss
     },
     menuIcon: {
       color: isDrawerOpen ? '#E30342' : 'black',
-      '& svg': { fontSize: '2em' },
+      '& svg': {
+        fontSize: '2em',
+      },
     },
     menu: {
       zIndex: 1000,
       '& .MuiDrawer-paper': {
         minWidth: '250px',
+      },
+    },
+    rightButtons: {
+      flexDirection: 'row',
+      marginLeft: 'auto',
+      gap: '1rem',
+      '& button': {
+        color: 'black',
+        '& svg': {
+          fontSize: '2em',
+        },
       },
     },
     headerClose: {
@@ -155,9 +178,10 @@ const useStyles = tss
     headerLogo: {
       height: '50px',
     },
-    closeIcon: {
-      color: 'black',
-      '& svg': { fontSize: '2em' },
+    fullscreenIcon: {
+      '& svg': {
+        transform: 'scale(0.7)',
+      },
     },
     headerTitle: {
       paddingLeft: '1em',

--- a/src/ui/components/orchestrator/tools/useFullscreen.test.ts
+++ b/src/ui/components/orchestrator/tools/useFullscreen.test.ts
@@ -1,0 +1,57 @@
+import { act, renderHook } from '@testing-library/react'
+import { beforeAll, describe, expect, it, vi } from 'vitest'
+
+import { useFullscreen } from './useFullscreen'
+
+beforeAll(() => {
+  document.documentElement.requestFullscreen = vi
+    .fn()
+    .mockResolvedValue(undefined)
+  document.exitFullscreen = vi.fn().mockResolvedValue(undefined)
+})
+
+describe('useFullscreen hook', () => {
+  it('should initialize with fullscreen as false', () => {
+    const { result } = renderHook(() => useFullscreen())
+
+    expect(result.current.isFullscreen).toBe(false)
+  })
+
+  it('should toggle fullscreen state correctly', async () => {
+    const { result } = renderHook(() => useFullscreen())
+
+    // initially not in fullscreen
+    expect(result.current.isFullscreen).toBe(false)
+
+    // toggle fullscreen
+    await act(async () => {
+      await result.current.toggleFullscreen()
+    })
+
+    // check it is in fullscreen
+    expect(result.current.isFullscreen).toBe(true)
+
+    // toggle fullscreen again
+    await act(async () => {
+      await result.current.toggleFullscreen()
+    })
+
+    // check it is not in fulscreen
+    expect(result.current.isFullscreen).toBe(false)
+  })
+
+  it('should exit fullscreen on component unmount', async () => {
+    const { result, unmount } = renderHook(() => useFullscreen())
+
+    // toggle fullscreen
+    await act(async () => {
+      await result.current.toggleFullscreen()
+    })
+    expect(result.current.isFullscreen).toBe(true)
+
+    unmount()
+
+    // check exitFullscreen has been called
+    expect(document.exitFullscreen).toHaveBeenCalled()
+  })
+})

--- a/src/ui/components/orchestrator/tools/useFullscreen.ts
+++ b/src/ui/components/orchestrator/tools/useFullscreen.ts
@@ -1,0 +1,92 @@
+import { useEffect, useState } from 'react'
+
+interface DocumentElementWithFullscreen extends HTMLElement {
+  msRequestFullscreen?: () => Promise<void>
+  mozRequestFullScreen?: () => Promise<void>
+  webkitRequestFullscreen?: () => Promise<void>
+}
+
+interface DocumentWithFullscreen extends Document {
+  mozFullScreenElement?: Element
+  msFullscreenElement?: Element
+  webkitFullscreenElement?: Element
+  msExitFullscreen?: () => Promise<void>
+  mozCancelFullScreen?: () => Promise<void>
+  webkitExitFullscreen?: () => Promise<void>
+}
+
+// Check if the document is in fullscreen mode
+const isDocumentFullscreen = (): boolean => {
+  const doc = document as DocumentWithFullscreen
+  return !!(
+    doc.fullscreenElement ||
+    doc.mozFullScreenElement ||
+    doc.webkitFullscreenElement ||
+    doc.msFullscreenElement
+  )
+}
+
+// Request fullscreen mode
+const requestFullscreen = async (element: DocumentElementWithFullscreen) => {
+  if (element.requestFullscreen) await element.requestFullscreen()
+  else if (element.msRequestFullscreen) await element.msRequestFullscreen()
+  else if (element.webkitRequestFullscreen)
+    await element.webkitRequestFullscreen()
+  else if (element.mozRequestFullScreen) await element.mozRequestFullScreen()
+}
+
+// Exit fullscreen mode
+const exitFullscreen = async (doc: DocumentWithFullscreen) => {
+  if (doc.exitFullscreen) await doc.exitFullscreen()
+  else if (doc.msExitFullscreen) await doc.msExitFullscreen()
+  else if (doc.webkitExitFullscreen) await doc.webkitExitFullscreen()
+  else if (doc.mozCancelFullScreen) await doc.mozCancelFullScreen()
+}
+
+export function useFullscreen() {
+  const [isFullscreen, setIsFullscreen] = useState(false)
+
+  const toggleFullscreen = async (): Promise<void> => {
+    if (!isFullscreen) {
+      await requestFullscreen(document.documentElement)
+    } else {
+      await exitFullscreen(document)
+    }
+    setIsFullscreen(!isFullscreen)
+  }
+
+  useEffect(() => {
+    const handleFullscreenChange = () => {
+      setIsFullscreen(isDocumentFullscreen())
+    }
+
+    // Add event listeners for fullscreen change across different browsers
+    document.addEventListener('fullscreenchange', handleFullscreenChange)
+    document.addEventListener('webkitfullscreenchange', handleFullscreenChange)
+    document.addEventListener('mozfullscreenchange', handleFullscreenChange)
+    document.addEventListener('msfullscreenchange', handleFullscreenChange)
+
+    return () => {
+      // Remove event listeners when component unmounts
+      document.removeEventListener('fullscreenchange', handleFullscreenChange)
+      document.removeEventListener(
+        'webkitfullscreenchange',
+        handleFullscreenChange,
+      )
+      document.removeEventListener(
+        'mozfullscreenchange',
+        handleFullscreenChange,
+      )
+      document.removeEventListener('msfullscreenchange', handleFullscreenChange)
+    }
+  }, [])
+
+  // Exit fullscreen when the component unmounts
+  useEffect(() => {
+    return () => {
+      exitFullscreen(document)
+    }
+  }, [])
+
+  return { toggleFullscreen, isFullscreen }
+}


### PR DESCRIPTION
Add possibility of going fullscreen in orchestrator.

Works well, except one problem : with virtual keyboard, the navigator does not handle the fullscreen resize when keyboard opens/closes ; so fixed items (like missing & continue buttons, navigation bar) are hidden by the keyboard.
We could use navigator.virtualKeyboard but it's not compatible with Firefox.

If someone has an idea to handle this problem, else we can close it since it was not asked but more an improvement i wanted