### PR TITLE
feat: field characters count

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.0",
-    "@inseefr/lunatic": "^3.4.18",
+    "@inseefr/lunatic": "^3.4.19",
     "@mui/icons-material": "^5.15.14",
     "@mui/material": "^5.15.14",
     "@types/memoizee": "^0.4.11",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -14,7 +14,7 @@ sonar.test.inclusions=src/**/*.test.js, src/**/*.test.jsx,src/**/*.test.ts, src/
 
 # Coverage
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
-sonar.coverage.exclusions=src/**/*.test.js, src/**/*.test.jsx, src/**/*.test.ts, src/**/*.test.tsx
+sonar.coverage.exclusions=src/**/*.test.js, src/**/*.test.jsx, src/**/*.test.ts, src/**/*.test.tsx, src/ui/components/orchestrator/lunaticStyle.tsx
 
 # Source encoding
 sonar.sourceEncoding=UTF-8

--- a/src/ui/components/orchestrator/lunaticStyle.tsx
+++ b/src/ui/components/orchestrator/lunaticStyle.tsx
@@ -64,7 +64,6 @@ export const useLunaticStyles = tss.create(({ theme }) => ({
     /* Firefox */
     '& input[type=text]': {
       MozAppearance: 'textfield',
-      marginBottom: '1em',
       padding: '0.45rem 0 0.45rem 0.45rem',
       minWidth: '40%',
       borderRadius: '10px',
@@ -79,6 +78,39 @@ export const useLunaticStyles = tss.create(({ theme }) => ({
       border: '1px solid black',
       backgroundColor: 'white',
     },
+
+    // characters count for text fields
+    '& .lunatic-input, .lunatic-textarea ': {
+      '& .field-with-count': {
+        display: 'flex',
+        flexDirection: 'column',
+        marginBottom: '1em',
+        gap: '0.5rem',
+
+        '& .characters-count': {
+          fontSize: '0.9rem',
+          fontWeight: 700,
+          color: '#666666',
+          textAlign: 'right',
+        },
+        '& .max-length-reached': {
+          color: 'red',
+        },
+      },
+    },
+    '& .lunatic-input .field-with-count': {
+      width: '40%',
+    },
+    '& .lunatic-table .lunatic-input .field-with-count': {
+      width: 'auto',
+    },
+    '& .lunatic-textarea .field-with-count': {
+      width: '80%',
+      '& textarea': {
+        resize: 'vertical',
+      },
+    },
+
     // unit for lunatic-input-number
     '& .lunatic-input-number > span': {
       position: 'relative',
@@ -170,8 +202,6 @@ export const useLunaticStyles = tss.create(({ theme }) => ({
       padding: '0.5rem',
       borderRadius: '10px',
       border: `${borderInput}`,
-      width: '55%',
-      minWidth: '200px',
       height: '10em',
       '&:focus': {
         outline: 'none',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1385,10 +1385,10 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/retry/-/retry-0.4.1.tgz#9a96ce501bc62df46c4031fbd970e3cc6b10f07b"
   integrity sha512-c7hNEllBlenFTHBky65mhq8WD2kbN9Q6gk0bTk8lSBvc554jpXSkST1iePudpt7+A/AQvuHs9EMqjHDXMY1lrA==
 
-"@inseefr/lunatic@^3.4.18":
-  version "3.4.18"
-  resolved "https://registry.yarnpkg.com/@inseefr/lunatic/-/lunatic-3.4.18.tgz#e400abf1d9e93669dcf47d16d6f7a735416d7e30"
-  integrity sha512-MFy6O3l6LnFzgaR6smYO8+j3nEv4tMjWTEHSoh18IcFF894uQ10lK/bJfVETMBW0xB8Zbzqm7uoOg6FvOwdxgg==
+"@inseefr/lunatic@^3.4.19":
+  version "3.4.19"
+  resolved "https://registry.yarnpkg.com/@inseefr/lunatic/-/lunatic-3.4.19.tgz#714286918b83248db4728f70ac84bd5a9f56438c"
+  integrity sha512-N8M2/IqbxjGRimn33qsxl2AIGfSRkeI1MRAC+kK8bN7/sgIs5KfBGk6qiinPMkEAAI9Ct92Eu5J2QrhES9mr6A==
   dependencies:
     "@inseefr/trevas" "^0.1.21"
     "@inseefr/vtl-2.0-antlr-tools" "^0.3.2"


### PR DESCRIPTION
Handle characters count on input & textarea (managed by Lunatic 3.4.19)

For textarea, we also increased its default width, and remove the horizontal resize for keeping the character count on bottom right of the field

---

I also excluded the lunaticStyle file from sonar coverage, since it's a .tsx only handling the style applied to Lunatic classes. It has no reason to be tested and often makes sonar analysis fail for no good reason.
=> in a further PR, file will be changed into a .ts instead of .tsx