### PR TITLE
feat(synchronize): handle 423 response on put surveyUnit as success

### DIFF
--- a/src/core/usecases/synchronizeData/thunks.ts
+++ b/src/core/usecases/synchronizeData/thunks.ts
@@ -328,6 +328,10 @@ export const thunks = {
             queenApi
               .putSurveyUnit(surveyUnit)
               .catch((error: AxiosError) => {
+                // handle response 423 as a success
+                if (error.response!.status === 423) {
+                  return Promise.resolve()
+                }
                 if (
                   error.response &&
                   [400, 403, 404, 500].includes(error.response.status)


### PR DESCRIPTION
During synchro, handle 423 response for put SurveyUnit as a success (since it's now a response that can be returned by api when we put a validated questionnaire)