### PR TITLE
style: handle lunatic tooltips

### DIFF
--- a/src/ui/components/orchestrator/lunaticStyle.tsx
+++ b/src/ui/components/orchestrator/lunaticStyle.tsx
@@ -634,5 +634,13 @@ export const useLunaticStyles = tss.create(({ theme }) => ({
         gridColumn: 1 / 3,
       },
     },
+
+    // tooltip
+    '.tooltip-content': {
+      maxWidth: '50%',
+      borderRadius: '5px',
+      opacity: 1,
+      fontWeight: '400 !important',
+    },
   },
 }))


### PR DESCRIPTION
handle lunatic tooltips style, especially width -> with a long content it was displayed on a single line and went out of screen