### PR TITLE
fix: lunatic component forced props

### DIFF
--- a/src/components/orchestrator/Orchestrator.tsx
+++ b/src/components/orchestrator/Orchestrator.tsx
@@ -205,10 +205,9 @@ export function Orchestrator({
                   components={components}
                   slots={slotComponents}
                   componentProps={() => ({
-                    disabled: readonly,
                     errors: activeErrors,
                     filterDescription: false,
-                    readOnly: readonly,
+                    ...(readonly ? { readOnly: true, disabled: true } : {}),
                   })}
                   autoFocusKey={pageTag}
                   wrapper={({ children, id, componentType }) => (

--- a/src/components/orchestrator/Orchestrator.tsx
+++ b/src/components/orchestrator/Orchestrator.tsx
@@ -206,7 +206,6 @@ export function Orchestrator({
                   slots={slotComponents}
                   componentProps={() => ({
                     errors: activeErrors,
-                    filterDescription: false,
                     ...(readonly ? { readOnly: true, disabled: true } : {}),
                   })}
                   autoFocusKey={pageTag}


### PR DESCRIPTION
When using the componentProps function in LunaticComponents, it forces the value for given props of all the components.

- readOnly & disabled : it's used to force to true when we are in readonly mode. But currently we also forced it wrongly to false when the orchestrator was not in readonly mode, instead of not forcing anything => not a problem for now, but would not work after we handle a readonly on some components : https://github.com/InseeFr/Lunatic/pull/1250
- filterDescription : not used anymore since the prop does not exist in any component anymore (now handled by a prop directly in the useLunatic)