### PR TITLE
fix: occurrence paginated loop

### DIFF
--- a/src/components/orchestrator/LoopPanel/LoopPanel.test.tsx
+++ b/src/components/orchestrator/LoopPanel/LoopPanel.test.tsx
@@ -114,6 +114,22 @@ describe('LoopPanel Component', () => {
     expect(container.firstChild).toBeNull()
   })
 
+  it('returns null in an occurrence paginated loop (titleData is a scalar variable)', () => {
+    const props = {
+      ...defaultProps,
+      data: {
+        COLLECTED: {
+          loopTitle: {
+            COLLECTED: 3,
+          },
+        },
+      },
+    }
+
+    const { container } = render(<LoopPanel {...props} />)
+    expect(container.firstChild).toBeNull()
+  })
+
   it('returns null if there is no data as title', () => {
     const props = {
       ...defaultProps,

--- a/src/components/orchestrator/LoopPanel/LoopPanel.tsx
+++ b/src/components/orchestrator/LoopPanel/LoopPanel.tsx
@@ -37,9 +37,9 @@ export function LoopPanel({
   const titleVariable = loopVariables[0]
 
   // get its collected value for every iteration
-  const titleData = data.COLLECTED[titleVariable]?.COLLECTED as unknown[]
+  const titleData = data.COLLECTED[titleVariable]?.COLLECTED
 
-  if (!titleData) {
+  if (!Array.isArray(titleData)) {
     return null
   }
 

--- a/src/components/orchestrator/Orchestrator.tsx
+++ b/src/components/orchestrator/Orchestrator.tsx
@@ -306,7 +306,11 @@ const useStyles = tss.create(({ theme }) => ({
     height: '100%',
     width: '80%',
     overflowY: 'auto',
-    '& > div:first-of-type': { display: 'flex', height: '100%' },
+    '& > div:first-of-type': {
+      display: 'flex',
+      flexDirection: 'column',
+      height: '100%',
+    },
     '& > div:first-of-type > div': {
       maxWidth: 'calc(100% - 100px)',
       paddingLeft: '100px',


### PR DESCRIPTION
On occurrence paginated loop, the LoopPanel crashed.
As for non paginated loop, now we don't display it