### PR TITLE
chore(deps): switch hotkeys library to react-hotkeys-hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.51.1",
-    "react-hot-keys": "^2.7.3",
+    "react-hotkeys-hook": "^5.1.0",
     "react-router-dom": "^6.26.2",
     "redux-clean-architecture": "^4.3.2",
     "tsafe": "^1.6.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,9 +61,9 @@ importers:
       react-hook-form:
         specifier: ^7.51.1
         version: 7.60.0(react@18.3.1)
-      react-hot-keys:
-        specifier: ^2.7.3
-        version: 2.7.3(@babel/runtime@7.27.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-hotkeys-hook:
+        specifier: ^5.1.0
+        version: 5.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-router-dom:
         specifier: ^6.26.2
         version: 6.30.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -4277,12 +4277,6 @@ packages:
         integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==,
       }
 
-  hotkeys-js@3.13.7:
-    resolution:
-      {
-        integrity: sha512-ygFIdTqqwG4fFP7kkiYlvayZppeIQX2aPpirsngkv1xM1lP0piDY5QEh68nQnIKvz64hfocxhBaD/uK3sSK1yQ==,
-      }
-
   html-encoding-sniffer@3.0.0:
     resolution:
       {
@@ -5804,15 +5798,14 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18 || ^19
 
-  react-hot-keys@2.7.3:
+  react-hotkeys-hook@5.1.0:
     resolution:
       {
-        integrity: sha512-OoX1kTookqQx/OBXBgBLQCANpw3KGUcJNOl+MNv8xJYyH/Rojv+jTjQbksDGQMIOWVfvLqOZi/ZVcVdsWUAUWg==,
+        integrity: sha512-GCNGXjBzV9buOS3REoQFmSmE4WTvBhYQ0YrAeeMZI83bhXg3dRWsLHXDutcVDdEjwJqJCxk5iewWYX5LtFUd7g==,
       }
     peerDependencies:
-      '@babel/runtime': '>=7.10.0'
-      react: '>=16.9.0'
-      react-dom: '>=16.9.0'
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
 
   react-is@16.13.1:
     resolution:
@@ -10081,8 +10074,6 @@ snapshots:
     dependencies:
       react-is: 16.13.1
 
-  hotkeys-js@3.13.7: {}
-
   html-encoding-sniffer@3.0.0:
     dependencies:
       whatwg-encoding: 2.0.0
@@ -11046,11 +11037,8 @@ snapshots:
     dependencies:
       react: 18.3.1
 
-  react-hot-keys@2.7.3(@babel/runtime@7.27.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-hotkeys-hook@5.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@babel/runtime': 7.27.6
-      hotkeys-js: 3.13.7
-      prop-types: 15.8.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 

--- a/src/components/ui/ShortCut.tsx
+++ b/src/components/ui/ShortCut.tsx
@@ -1,31 +1,22 @@
-import ReactHotkeys from 'react-hot-keys'
+import { useHotkeys } from 'react-hotkeys-hook'
 
 type ShortCutProps = {
   shortCutKey: string
   onClickMethod: () => void
 }
 
-/** Allow to add an action that will be triggered through a hotkey. */
 export function ShortCut({
   shortCutKey,
   onClickMethod,
 }: Readonly<ShortCutProps>) {
-  function onClickShortCut(onClickMethod: () => void) {
-    return (_keyName: string, event: KeyboardEvent) => {
+  useHotkeys(
+    shortCutKey,
+    (event) => {
       onClickMethod()
       event.preventDefault()
-    }
-  }
-
-  const handleShortCut = onClickShortCut(onClickMethod)
-
-  // filter ables to overload native navigation
-  return (
-    <ReactHotkeys
-      key={shortCutKey}
-      keyName={shortCutKey}
-      onKeyDown={handleShortCut}
-      filter={() => true}
-    />
+    },
+    { preventDefault: true, enableOnFormTags: ['input', 'select', 'textarea'] },
   )
+
+  return null
 }


### PR DESCRIPTION
At the moment, I kept switched library but I kept the old component just in case. Feel free to give me your opinion on this. 
I also kept the previous handling mechanism. It may not be the optimal solution