### PR TITLE
fix: prevent shortcut without pressing alt key

### DIFF
--- a/src/components/orchestrator/hooks/useShortcut.ts
+++ b/src/components/orchestrator/hooks/useShortcut.ts
@@ -11,9 +11,24 @@ export function useShortcut(
   onClickMethod: () => void,
   isShortcutEnabled: boolean = true,
 ) {
+  const requiresAlt = shortCutKey.toLowerCase().includes('alt+')
+  const requiresCtrl = shortCutKey.toLowerCase().includes('ctrl+')
+  const requiresShift = shortCutKey.toLowerCase().includes('shift+')
+
   useHotkeys(
     shortCutKey,
     (event) => {
+      // With `useKey` option activated, currently shortcut is triggered even if ctrl/alt/shift key is not pressed.
+      // This is a quick fix to remove when it will be handled by the library.
+      // See https://github.com/JohannesKlauss/react-hotkeys-hook/issues/1274
+      if (
+        (requiresAlt && !event.altKey) ||
+        (requiresCtrl && !event.ctrlKey) ||
+        (requiresShift && !event.shiftKey)
+      ) {
+        return
+      }
+
       event.preventDefault()
       onClickMethod()
     },


### PR DESCRIPTION
Since we switched the library for shortcut (https://github.com/InseeFr/Drama-Queen/pull/361)

Shortcuts using special keys for combination like "alt" were triggered even without pressing this special key.

For now we need a quickfix until it's fixed by the library.
The only other solution would be to rollback to the previous library we used