### PR TITLE
feat(synchronize): upload only updated interrogations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Improve synchronization performance : for download step, the list of interrogations is now retrieved from local storage (given by the parent app). If there is nothing in local storage, we keep the old implementation using api.
+- Improve synchronization performance : for upload step, we now upload only interrogations that have been locally updated since it was last sent to the server.
 
 ## [3.3.2](https://github.com/InseeFr/Drama-Queen/releases/tag/3.3.2) - 2026-04-14
 

--- a/src/core/adapters/datastore/default.test.ts
+++ b/src/core/adapters/datastore/default.test.ts
@@ -1,18 +1,8 @@
 import Dexie from 'dexie'
 
-import type {
-  Interrogation,
-  InterrogationData,
-  LocalInterrogation,
-} from '@/core/model'
+import type { Interrogation, InterrogationData } from '@/core/model'
 
-import {
-  createDataStore,
-  dbVersion2,
-  dbVersion3,
-  dbVersion4,
-  dbVersion5,
-} from './default'
+import { createDataStore, dbVersion2, dbVersion3, dbVersion4 } from './default'
 
 describe('createDataStore', () => {
   describe('Dexie migration v2 → latest version', () => {
@@ -55,12 +45,7 @@ describe('createDataStore', () => {
 
       // Check all surveyUnits have been migrated into interrogations in interrogation table
       const interrogations = await store.getAllInterrogations()
-      // After migration, all interrogations should have hasBeenUpdated: true
-      const expectedInterrogations = surveyUnits.map((su) => ({
-        ...su,
-        hasBeenUpdated: true,
-      }))
-      expect(interrogations).toEqual(expectedInterrogations)
+      expect(interrogations).toEqual(surveyUnits)
     }, 30000) // 30 seconds timeout for this stress test
   })
 
@@ -90,12 +75,8 @@ describe('createDataStore', () => {
       // Create new data store to trigger migration
       const store = createDataStore()
 
-      // Check that interrogations remain untouched but now have hasBeenUpdated field
-      const migratedInterrogations =
-        (await store.getAllInterrogations()) as LocalInterrogation[]
-      expect(migratedInterrogations).toEqual([
-        { ...interrogation, hasBeenUpdated: true },
-      ])
+      // Check that interrogations remain untouched
+      expect(await store.getAllInterrogations()).toEqual([interrogation])
 
       // Check that surveyUnit table has been removed
       const tableNames = store.db.tables.map((t) => t.name)
@@ -134,65 +115,12 @@ describe('createDataStore', () => {
       // Create new data store to trigger migration
       const store = createDataStore()
 
-      // Check that interrogations remain untouched but now have hasBeenUpdated field
-      const migratedInterrogations =
-        (await store.getAllInterrogations()) as LocalInterrogation[]
-      expect(migratedInterrogations).toEqual([
-        { ...interrogation, hasBeenUpdated: true },
-      ])
+      // Check that interrogations remain untouched
+      expect(await store.getAllInterrogations()).toEqual([interrogation])
 
       // Check new paradata table exists and is empty
       const paradata = await store.getAllParadata()
       expect(paradata).toEqual([])
-    })
-  })
-
-  describe('Dexie migration v5 → latest version', () => {
-    beforeEach(async () => {
-      await Dexie.delete('Queen')
-    })
-
-    it('adds hasBeenUpdated field to existing interrogations', async () => {
-      // Create DB at version 5
-      const dbV5 = new Dexie('Queen')
-      dbVersion2(dbV5)
-      dbVersion3(dbV5)
-      dbVersion4(dbV5)
-      dbVersion5(dbV5)
-
-      const interrogations: Interrogation[] = [
-        {
-          id: 'INTERRO001',
-          questionnaireId: 'Q1',
-          data: { COLLECTED: { prenom: { COLLECTED: 'Paul' } } },
-          stateData: { state: 'INIT', date: 17000000, currentPage: '1' },
-        },
-        {
-          id: 'INTERRO002',
-          questionnaireId: 'Q2',
-          data: { COLLECTED: { nom: { COLLECTED: 'Dupont' } } },
-          stateData: { state: 'COMPLETED', date: 17000000, currentPage: '5' },
-        },
-      ]
-
-      await dbV5.table('interrogation').bulkPut(interrogations)
-
-      // Close the database before applying the migration
-      dbV5.close()
-
-      // Create new data store to trigger migration
-      const store = createDataStore()
-
-      // Check that interrogations remain untouched but now have hasBeenUpdated field with `true` value
-      const migratedInterrogations =
-        (await store.getAllInterrogations()) as LocalInterrogation[]
-      const expectedMigratedInterrogations = interrogations.map(
-        (interrogation) => ({
-          ...interrogation,
-          hasBeenUpdated: true,
-        }),
-      )
-      expect(migratedInterrogations).toEqual(expectedMigratedInterrogations)
     })
   })
 })

--- a/src/core/adapters/datastore/default.test.ts
+++ b/src/core/adapters/datastore/default.test.ts
@@ -1,8 +1,18 @@
 import Dexie from 'dexie'
 
-import type { Interrogation, InterrogationData } from '@/core/model'
+import type {
+  Interrogation,
+  InterrogationData,
+  LocalInterrogation,
+} from '@/core/model'
 
-import { createDataStore, dbVersion2, dbVersion3, dbVersion4 } from './default'
+import {
+  createDataStore,
+  dbVersion2,
+  dbVersion3,
+  dbVersion4,
+  dbVersion5,
+} from './default'
 
 describe('createDataStore', () => {
   describe('Dexie migration v2 → latest version', () => {
@@ -37,12 +47,20 @@ describe('createDataStore', () => {
       // Insert all surveyUnits in surveyUnit table
       await dbV2.table('surveyUnit').bulkPut(surveyUnits)
 
+      // Close the database before applying the migration
+      dbV2.close()
+
       // Create new data store to trigger migration to latest version
       const store = createDataStore()
 
       // Check all surveyUnits have been migrated into interrogations in interrogation table
       const interrogations = await store.getAllInterrogations()
-      expect(interrogations).toEqual(surveyUnits)
+      // After migration, all interrogations should have hasBeenUpdated: true
+      const expectedInterrogations = surveyUnits.map((su) => ({
+        ...su,
+        hasBeenUpdated: true,
+      }))
+      expect(interrogations).toEqual(expectedInterrogations)
     })
   })
 
@@ -66,11 +84,18 @@ describe('createDataStore', () => {
 
       await dbV3.table('interrogation').put(interrogation)
 
+      // Close the database before applying the migration
+      dbV3.close()
+
       // Create new data store to trigger migration
       const store = createDataStore()
 
-      // Check that interrogations remain untouched
-      expect(await store.getAllInterrogations()).toEqual([interrogation])
+      // Check that interrogations remain untouched but now have hasBeenUpdated field
+      const migratedInterrogations =
+        (await store.getAllInterrogations()) as LocalInterrogation[]
+      expect(migratedInterrogations).toEqual([
+        { ...interrogation, hasBeenUpdated: true },
+      ])
 
       // Check that surveyUnit table has been removed
       const tableNames = store.db.tables.map((t) => t.name)
@@ -103,15 +128,71 @@ describe('createDataStore', () => {
       const tableNames = dbV4.tables.map((t) => t.name)
       expect(tableNames).not.toContain('paradata')
 
+      // Close the database before applying the migration
+      dbV4.close()
+
       // Create new data store to trigger migration
       const store = createDataStore()
 
-      // Check that interrogations remain untouched
-      expect(await store.getAllInterrogations()).toEqual([interrogation])
+      // Check that interrogations remain untouched but now have hasBeenUpdated field
+      const migratedInterrogations =
+        (await store.getAllInterrogations()) as LocalInterrogation[]
+      expect(migratedInterrogations).toEqual([
+        { ...interrogation, hasBeenUpdated: true },
+      ])
 
       // Check new paradata table exists and is empty
       const paradata = await store.getAllParadata()
       expect(paradata).toEqual([])
+    })
+  })
+
+  describe('Dexie migration v5 → latest version', () => {
+    beforeEach(async () => {
+      await Dexie.delete('Queen')
+    })
+
+    it('adds hasBeenUpdated field to existing interrogations', async () => {
+      // Create DB at version 5
+      const dbV5 = new Dexie('Queen')
+      dbVersion2(dbV5)
+      dbVersion3(dbV5)
+      dbVersion4(dbV5)
+      dbVersion5(dbV5)
+
+      const interrogations: Interrogation[] = [
+        {
+          id: 'INTERRO001',
+          questionnaireId: 'Q1',
+          data: { COLLECTED: { prenom: { COLLECTED: 'Paul' } } },
+          stateData: { state: 'INIT', date: 17000000, currentPage: '1' },
+        },
+        {
+          id: 'INTERRO002',
+          questionnaireId: 'Q2',
+          data: { COLLECTED: { nom: { COLLECTED: 'Dupont' } } },
+          stateData: { state: 'COMPLETED', date: 17000000, currentPage: '5' },
+        },
+      ]
+
+      await dbV5.table('interrogation').bulkPut(interrogations)
+
+      // Close the database before applying the migration
+      dbV5.close()
+
+      // Create new data store to trigger migration
+      const store = createDataStore()
+
+      // Check that interrogations remain untouched but now have hasBeenUpdated field with `true` value
+      const migratedInterrogations =
+        (await store.getAllInterrogations()) as LocalInterrogation[]
+      const expectedMigratedInterrogations = interrogations.map(
+        (interrogation) => ({
+          ...interrogation,
+          hasBeenUpdated: true,
+        }),
+      )
+      expect(migratedInterrogations).toEqual(expectedMigratedInterrogations)
     })
   })
 })

--- a/src/core/adapters/datastore/default.test.ts
+++ b/src/core/adapters/datastore/default.test.ts
@@ -61,7 +61,7 @@ describe('createDataStore', () => {
         hasBeenUpdated: true,
       }))
       expect(interrogations).toEqual(expectedInterrogations)
-    })
+    }, 30000) // 30 seconds timeout for this stress test
   })
 
   describe('Dexie migration v3 → latest version', () => {

--- a/src/core/adapters/datastore/default.ts
+++ b/src/core/adapters/datastore/default.ts
@@ -106,19 +106,14 @@ export function dbVersion6(db: Dexie) {
     })
     .upgrade(async (tx) => {
       try {
-        const table = tx.table<LocalInterrogation, string>('interrogation')
-        const interrogations = await table.toArray()
-
-        // Set hasBeenUpdated: true for all existing interrogation
-        // Ensure all the interrogations updated before this migration will be sent at the next synchronization.
-        await Promise.all(
-          interrogations.map(async (interrogation) => {
-            await table.put({
-              ...interrogation,
-              hasBeenUpdated: true,
-            })
-          }),
-        )
+        return tx
+          .table<LocalInterrogation, string>('interrogation')
+          .toCollection()
+          .modify((interrogation) => {
+            // Set hasBeenUpdated: true for all existing interrogation
+            // Ensure all the interrogations updated before this migration will be sent at the next synchronization.
+            interrogation.hasBeenUpdated = true
+          })
       } catch (err) {
         console.error('Error during hasBeenUpdated migration', err)
       }

--- a/src/core/adapters/datastore/default.ts
+++ b/src/core/adapters/datastore/default.ts
@@ -1,11 +1,11 @@
 import Dexie, { type Table } from 'dexie'
 
 import { mockPrefixIdInterrogation } from '@/core/adapters/queenApi/mock'
-import type { Interrogation, Paradata } from '@/core/model'
+import type { Interrogation, LocalInterrogation, Paradata } from '@/core/model'
 import type { DataStore } from '@/core/ports/DataStore'
 
 type Tables = {
-  interrogation: Table<Interrogation, string>
+  interrogation: Table<LocalInterrogation, string>
   paradata: Table<Paradata>
 }
 
@@ -16,6 +16,7 @@ export function createDataStore(): DataStore & { db: Dexie & Tables } {
   dbVersion3(db)
   dbVersion4(db)
   dbVersion5(db)
+  dbVersion6(db)
 
   return {
     db, // only used for tests
@@ -92,4 +93,34 @@ export function dbVersion5(db: Dexie) {
   db.version(5).stores({
     paradata: '++idInterrogation',
   })
+}
+
+/**
+ * Adds hasBeenUpdated field to interrogation table.
+ */
+export function dbVersion6(db: Dexie) {
+  db.version(6)
+    .stores({
+      interrogation:
+        'id,data,stateData,personalization,comment,questionnaireId,hasBeenUpdated',
+    })
+    .upgrade(async (tx) => {
+      try {
+        const table = tx.table<LocalInterrogation, string>('interrogation')
+        const interrogations = await table.toArray()
+
+        // Set hasBeenUpdated: true for all existing interrogation
+        // Ensure all the interrogations updated before this migration will be sent at the next synchronization.
+        await Promise.all(
+          interrogations.map(async (interrogation) => {
+            await table.put({
+              ...interrogation,
+              hasBeenUpdated: true,
+            })
+          }),
+        )
+      } catch (err) {
+        console.error('Error during hasBeenUpdated migration', err)
+      }
+    })
 }

--- a/src/core/adapters/datastore/default.ts
+++ b/src/core/adapters/datastore/default.ts
@@ -16,7 +16,6 @@ export function createDataStore(): DataStore & { db: Dexie & Tables } {
   dbVersion3(db)
   dbVersion4(db)
   dbVersion5(db)
-  dbVersion6(db)
 
   return {
     db, // only used for tests
@@ -93,29 +92,4 @@ export function dbVersion5(db: Dexie) {
   db.version(5).stores({
     paradata: '++idInterrogation',
   })
-}
-
-/**
- * Adds hasBeenUpdated field to interrogation table.
- */
-export function dbVersion6(db: Dexie) {
-  db.version(6)
-    .stores({
-      interrogation:
-        'id,data,stateData,personalization,comment,questionnaireId,hasBeenUpdated',
-    })
-    .upgrade(async (tx) => {
-      try {
-        return tx
-          .table<LocalInterrogation, string>('interrogation')
-          .toCollection()
-          .modify((interrogation) => {
-            // Set hasBeenUpdated: true for all existing interrogation
-            // Ensure all the interrogations updated before this migration will be sent at the next synchronization.
-            interrogation.hasBeenUpdated = true
-          })
-      } catch (err) {
-        console.error('Error during hasBeenUpdated migration', err)
-      }
-    })
 }

--- a/src/core/model/Interrogation.ts
+++ b/src/core/model/Interrogation.ts
@@ -9,3 +9,9 @@ export type Interrogation = {
   comment?: { [key: string]: unknown }
   stateData?: StateData
 }
+
+/** Interrogation stored in local storage only */
+export type LocalInterrogation = Interrogation & {
+  /** Whether the interrogation has been updated locally since it was last sent to the server. */
+  hasBeenUpdated?: boolean
+}

--- a/src/core/ports/DataStore.ts
+++ b/src/core/ports/DataStore.ts
@@ -1,10 +1,10 @@
-import type { Interrogation, Paradata, TelemetryEvent } from '@/core/model'
+import type { LocalInterrogation, Paradata, TelemetryEvent } from '@/core/model'
 
 export type DataStore = {
-  updateInterrogation: (interrogation: Interrogation) => Promise<string>
+  updateInterrogation: (interrogation: LocalInterrogation) => Promise<string>
   deleteInterrogation: (id: string) => Promise<void>
-  getAllInterrogations: () => Promise<Interrogation[] | undefined>
-  getInterrogation: (id: string) => Promise<Interrogation | undefined>
+  getAllInterrogations: () => Promise<LocalInterrogation[] | undefined>
+  getInterrogation: (id: string) => Promise<LocalInterrogation | undefined>
   getAllParadata: () => Promise<Paradata[] | undefined>
   deleteParadata: (id: string) => Promise<void>
   getParadata: (id: string) => Promise<Paradata | undefined>

--- a/src/core/usecases/collectSurvey/thunks.test.ts
+++ b/src/core/usecases/collectSurvey/thunks.test.ts
@@ -129,9 +129,10 @@ describe('changePage', () => {
       mockContext as any,
     )
 
-    expect(mockDataStore.updateInterrogation).toHaveBeenCalledWith(
-      interrogation,
-    )
+    expect(mockDataStore.updateInterrogation).toHaveBeenCalledWith({
+      ...interrogation,
+      hasBeenUpdated: true,
+    })
   })
 })
 

--- a/src/core/usecases/collectSurvey/thunks.ts
+++ b/src/core/usecases/collectSurvey/thunks.ts
@@ -1,6 +1,6 @@
 import type { Thunks } from '@/core/bootstrap'
 import { LUNATIC_MODEL_VERSION_BREAKING } from '@/core/constants'
-import type { Interrogation, Paradata } from '@/core/model'
+import type { Interrogation, LocalInterrogation, Paradata } from '@/core/model'
 import type { QuestionnaireState } from '@/core/model/QuestionnaireState'
 import { isSurveyCompatibleWithQueen } from '@/core/tools/SurveyModelBreaking'
 import i18n from '@/libs/i18n'
@@ -60,7 +60,13 @@ export const thunks = {
     (...args) => {
       const [, , { dataStore }] = args
 
-      dataStore.updateInterrogation(interrogation).catch((error) => {
+      // Set hasBeenUpdated flag when saving data changes in collect mode
+      const updatedInterrogation: LocalInterrogation = {
+        ...interrogation,
+        hasBeenUpdated: true,
+      }
+
+      dataStore.updateInterrogation(updatedInterrogation).catch((error) => {
         console.error('Error updating or inserting record:', error)
       })
     },

--- a/src/core/usecases/interrogation/takeControl.ts
+++ b/src/core/usecases/interrogation/takeControl.ts
@@ -2,6 +2,7 @@ import { createSelector, createUsecaseActions } from 'redux-clean-architecture'
 import { id } from 'tsafe/id'
 
 import type { State as RootState, Thunks } from '@/core/bootstrap'
+import type { LocalInterrogation } from '@/core/model'
 import i18n from '@/libs/i18n'
 
 /**
@@ -52,7 +53,14 @@ export const thunks = {
         const interrogation = await queenApi.syncInterrogation(
           params.interrogationId,
         )
-        await dataStore.updateInterrogation(interrogation)
+
+        // Set hasBeenUpdated flag when taking control of an interrogation
+        const updatedInterrogation: LocalInterrogation = {
+          ...interrogation,
+          hasBeenUpdated: true,
+        }
+
+        await dataStore.updateInterrogation(updatedInterrogation)
         dispatch(actions.finished())
       } catch (e) {
         dispatch(actions.fail(e as Error))

--- a/src/core/usecases/synchronizeData/thunks.test.ts
+++ b/src/core/usecases/synchronizeData/thunks.test.ts
@@ -4,9 +4,10 @@ import {
   TELEMETRY_EVENT_EXIT_SOURCE,
   TELEMETRY_EVENT_TYPE,
 } from '@/constants/telemetry'
-import type { Interrogation, Paradata } from '@/core/model'
+import type { LocalInterrogation, Paradata } from '@/core/model'
 import type { DataStore } from '@/core/ports/DataStore'
 import type { LocalSyncStorage } from '@/core/ports/LocalSyncStorage'
+import { interrogationFromLocalInterrogation } from '@/utils/interrogation'
 
 import { type State } from './state'
 import { actions } from './state'
@@ -394,7 +395,7 @@ describe('upload thunk', () => {
     vi.clearAllMocks()
   })
 
-  it('should upload interrogations successfully', async () => {
+  it('should only upload interrogations that have been updated locally', async () => {
     // override global mock value for enable telemetry
     vi.doMock('@/core/constants', () => ({
       IS_TELEMETRY_ENABLED: true,
@@ -402,12 +403,40 @@ describe('upload thunk', () => {
     }))
     // Re-import after mocking
     const { thunks } = await import('./thunks')
-    const interrogations = [{ id: '1' }, { id: '2' }]
+    const interrogations: LocalInterrogation[] = [
+      {
+        id: '1',
+        questionnaireId: 'q1',
+        data: { COLLECTED: {} },
+        stateData: { state: 'INIT', date: 17000000, currentPage: '1' },
+        hasBeenUpdated: true,
+      },
+      {
+        id: '2',
+        questionnaireId: 'q1',
+        data: { COLLECTED: {} },
+        stateData: { state: 'INIT', date: 17000000, currentPage: '1' },
+        hasBeenUpdated: false,
+      },
+      {
+        id: '3',
+        questionnaireId: 'q1',
+        data: { COLLECTED: {} },
+        stateData: { state: 'INIT', date: 17000000, currentPage: '1' },
+        hasBeenUpdated: true,
+      },
+      {
+        id: '4',
+        questionnaireId: 'q1',
+        data: { COLLECTED: {} },
+        stateData: { state: 'INIT', date: 17000000, currentPage: '1' },
+      }, // undefined `hasBeenUpdated` should be treated as false
+    ]
+
     vi.mocked(mockDataStore.getAllInterrogations).mockResolvedValue(
-      interrogations as Interrogation[],
+      interrogations as LocalInterrogation[],
     )
     vi.mocked(mockQueenApi.putInterrogation).mockResolvedValue(undefined)
-    vi.mocked(mockDataStore.deleteInterrogation).mockResolvedValue(undefined)
     // no paradata
     vi.mocked(mockDataStore.getAllParadata).mockResolvedValue([])
 
@@ -420,9 +449,17 @@ describe('upload thunk', () => {
     )
     expect(uploadInterrogationCalls).toHaveLength(2)
 
+    expect(mockQueenApi.putInterrogation).toHaveBeenCalledTimes(2)
+    expect(mockQueenApi.putInterrogation).toHaveBeenCalledWith(
+      interrogationFromLocalInterrogation(interrogations[0]),
+    )
+    expect(mockQueenApi.putInterrogation).toHaveBeenCalledWith(
+      interrogationFromLocalInterrogation(interrogations[2]),
+    )
+
     expect(mockDispatch).toHaveBeenCalledWith(
       actions.setUploadTotalInterrogation({
-        totalInterrogation: interrogations.length,
+        totalInterrogation: 2,
       }),
     )
     expect(mockDispatch).toHaveBeenCalledWith(actions.uploadCompleted())
@@ -434,11 +471,42 @@ describe('upload thunk', () => {
     expect(mockDispatch).toHaveBeenCalledTimes(6)
   })
 
-  it('should handle interrogation upload failure and retry posting to temp zone', async () => {
-    const interrogation = { id: '1' }
+  it('should set interrogations as not updated after successful upload', async () => {
+    const interrogation: LocalInterrogation = {
+      id: '1',
+      questionnaireId: 'q1',
+      data: { COLLECTED: {} },
+      stateData: { state: 'INIT', date: 17000000, currentPage: '1' },
+      hasBeenUpdated: true,
+    }
+
     vi.mocked(mockDataStore.getAllInterrogations).mockResolvedValue([
       interrogation,
-    ] as Interrogation[])
+    ])
+    vi.mocked(mockQueenApi.putInterrogation).mockResolvedValue(undefined)
+    vi.mocked(mockDataStore.getAllParadata).mockResolvedValue([])
+
+    await thunks.upload()(mockDispatch, mockGetState, mockContext as any)
+
+    // Should set interrogation locally as not updated
+    expect(mockDataStore.updateInterrogation).toHaveBeenCalledWith({
+      ...interrogation,
+      hasBeenUpdated: false,
+    })
+  })
+
+  it('should handle interrogation upload failure and retry posting to temp zone', async () => {
+    const interrogation: LocalInterrogation = {
+      id: '1',
+      questionnaireId: 'q1',
+      data: { COLLECTED: {} },
+      stateData: { state: 'INIT', date: 17000000, currentPage: '1' },
+      hasBeenUpdated: true,
+    }
+
+    vi.mocked(mockDataStore.getAllInterrogations).mockResolvedValue([
+      interrogation,
+    ] as LocalInterrogation[])
     vi.mocked(mockQueenApi.putInterrogation).mockRejectedValue({
       response: { status: 400 },
     })
@@ -448,7 +516,7 @@ describe('upload thunk', () => {
     await thunks.upload()(mockDispatch, mockGetState, mockContext as any)
 
     expect(mockQueenApi.postInterrogationInTemp).toHaveBeenCalledWith(
-      interrogation,
+      interrogationFromLocalInterrogation(interrogation),
     )
     expect(
       mockLocalSyncStorage.addIdToInterrogationsInTempZone,
@@ -457,25 +525,32 @@ describe('upload thunk', () => {
   })
 
   it('should treat 423 response for interrogation as a success', async () => {
-    const interrogation = { id: '1' }
+    const interrogation: LocalInterrogation = {
+      id: '1',
+      questionnaireId: 'q1',
+      data: { COLLECTED: {} },
+      stateData: { state: 'INIT', date: 17000000, currentPage: '1' },
+      hasBeenUpdated: true,
+    }
 
     vi.mocked(mockDataStore.getAllInterrogations).mockResolvedValue([
       interrogation,
-    ] as Interrogation[])
+    ] as any)
     vi.mocked(mockQueenApi.putInterrogation).mockRejectedValue({
       response: { status: 423 },
     })
 
     vi.mocked(mockQueenApi.postInterrogationInTemp).mockResolvedValue(undefined)
-    vi.mocked(mockDataStore.deleteInterrogation).mockResolvedValue(undefined)
+    vi.mocked(mockDataStore.updateInterrogation).mockResolvedValue('1')
 
     await thunks.upload()(mockDispatch, mockGetState, mockContext as any)
 
     // Expect it to continue as if it were a success
     expect(mockQueenApi.postInterrogationInTemp).not.toHaveBeenCalled()
-    expect(mockDataStore.deleteInterrogation).toHaveBeenCalledWith(
-      interrogation.id,
-    )
+    expect(mockDataStore.updateInterrogation).toHaveBeenCalledWith({
+      ...interrogation,
+      hasBeenUpdated: false,
+    })
     expect(mockDispatch).toHaveBeenCalledWith(
       actions.uploadInterrogationCompleted(),
     )
@@ -498,7 +573,13 @@ describe('upload thunk', () => {
   })
 
   it('should delete paradata without sending it when interrogation upload fails', async () => {
-    const interrogation = { id: '1' }
+    const interrogation: LocalInterrogation = {
+      id: '1',
+      questionnaireId: 'q1',
+      data: { COLLECTED: {} },
+      stateData: { state: 'INIT', date: 17000000, currentPage: '1' },
+      hasBeenUpdated: true,
+    }
     const allParadata: Paradata[] = [
       {
         idInterrogation: '1',
@@ -514,7 +595,7 @@ describe('upload thunk', () => {
 
     vi.mocked(mockDataStore.getAllInterrogations).mockResolvedValue([
       interrogation,
-    ] as Interrogation[])
+    ] as any)
     vi.mocked(mockQueenApi.putInterrogation).mockRejectedValue({
       response: { status: 400 },
     })
@@ -527,7 +608,7 @@ describe('upload thunk', () => {
 
     // The post to temp should happen
     expect(mockQueenApi.postInterrogationInTemp).toHaveBeenCalledWith(
-      interrogation,
+      interrogationFromLocalInterrogation(interrogation),
     )
     // The paradata for this interrogation should be deleted
     expect(mockDataStore.deleteParadata).toHaveBeenCalledWith(interrogation.id)

--- a/src/core/usecases/synchronizeData/thunks.test.ts
+++ b/src/core/usecases/synchronizeData/thunks.test.ts
@@ -506,7 +506,7 @@ describe('upload thunk', () => {
 
     vi.mocked(mockDataStore.getAllInterrogations).mockResolvedValue([
       interrogation,
-    ] as LocalInterrogation[])
+    ])
     vi.mocked(mockQueenApi.putInterrogation).mockRejectedValue({
       response: { status: 400 },
     })
@@ -535,7 +535,7 @@ describe('upload thunk', () => {
 
     vi.mocked(mockDataStore.getAllInterrogations).mockResolvedValue([
       interrogation,
-    ] as any)
+    ])
     vi.mocked(mockQueenApi.putInterrogation).mockRejectedValue({
       response: { status: 423 },
     })
@@ -595,7 +595,7 @@ describe('upload thunk', () => {
 
     vi.mocked(mockDataStore.getAllInterrogations).mockResolvedValue([
       interrogation,
-    ] as any)
+    ])
     vi.mocked(mockQueenApi.putInterrogation).mockRejectedValue({
       response: { status: 400 },
     })

--- a/src/core/usecases/synchronizeData/thunks.test.ts
+++ b/src/core/usecases/synchronizeData/thunks.test.ts
@@ -430,7 +430,7 @@ describe('upload thunk', () => {
         questionnaireId: 'q1',
         data: { COLLECTED: {} },
         stateData: { state: 'INIT', date: 17000000, currentPage: '1' },
-      }, // undefined `hasBeenUpdated` should be treated as false
+      }, // undefined `hasBeenUpdated` should be treated as true
     ]
 
     vi.mocked(mockDataStore.getAllInterrogations).mockResolvedValue(
@@ -447,19 +447,22 @@ describe('upload thunk', () => {
     const uploadInterrogationCalls = mockDispatch.mock.calls.filter(
       ([action]) => action.type === actions.uploadInterrogationCompleted().type,
     )
-    expect(uploadInterrogationCalls).toHaveLength(2)
+    expect(uploadInterrogationCalls).toHaveLength(3)
 
-    expect(mockQueenApi.putInterrogation).toHaveBeenCalledTimes(2)
+    expect(mockQueenApi.putInterrogation).toHaveBeenCalledTimes(3)
     expect(mockQueenApi.putInterrogation).toHaveBeenCalledWith(
       interrogationFromLocalInterrogation(interrogations[0]),
     )
     expect(mockQueenApi.putInterrogation).toHaveBeenCalledWith(
       interrogationFromLocalInterrogation(interrogations[2]),
     )
+    expect(mockQueenApi.putInterrogation).toHaveBeenCalledWith(
+      interrogationFromLocalInterrogation(interrogations[3]),
+    )
 
     expect(mockDispatch).toHaveBeenCalledWith(
       actions.setUploadTotalInterrogation({
-        totalInterrogation: 2,
+        totalInterrogation: 3,
       }),
     )
     expect(mockDispatch).toHaveBeenCalledWith(actions.uploadCompleted())
@@ -468,7 +471,7 @@ describe('upload thunk', () => {
      * Cannot do directly expect(mockDispatch).toHaveBeenCalledWith(thunks.download())
      * since it considers it has been called with [AsyncFunction (anonymous)]
      */
-    expect(mockDispatch).toHaveBeenCalledTimes(6)
+    expect(mockDispatch).toHaveBeenCalledTimes(7)
   })
 
   it('should set interrogations as not updated after successful upload', async () => {

--- a/src/core/usecases/synchronizeData/thunks.test.ts
+++ b/src/core/usecases/synchronizeData/thunks.test.ts
@@ -4,7 +4,7 @@ import {
   TELEMETRY_EVENT_EXIT_SOURCE,
   TELEMETRY_EVENT_TYPE,
 } from '@/constants/telemetry'
-import type { LocalInterrogation, Paradata } from '@/core/model'
+import type { Interrogation, LocalInterrogation, Paradata } from '@/core/model'
 import type { DataStore } from '@/core/ports/DataStore'
 import type { LocalSyncStorage } from '@/core/ports/LocalSyncStorage'
 import { interrogationFromLocalInterrogation } from '@/utils/interrogation'
@@ -83,9 +83,20 @@ describe('download thunk', () => {
     // Re-import after mocking
     const { thunks } = await import('./thunks')
 
+    const interro1: Interrogation = {
+      id: 'interro1',
+      questionnaireId: 'q1',
+      data: {},
+    }
+    const interro2: Interrogation = {
+      id: 'interro2',
+      questionnaireId: 'q1',
+      data: {},
+    }
+
     vi.mocked(mockQueenApi.getInterrogation)
-      .mockResolvedValueOnce({ id: 'interro1', questionnaireId: 'q1' })
-      .mockResolvedValueOnce({ id: 'interro2', questionnaireId: 'q1' })
+      .mockResolvedValueOnce(interro1)
+      .mockResolvedValueOnce(interro2)
     vi.mocked(mockQueenApi.getQuestionnaire).mockResolvedValue({ id: 'q1' })
 
     await thunks.download()(mockDispatch, mockGetState, mockContext as any)
@@ -94,6 +105,17 @@ describe('download thunk', () => {
     expect(mockDispatch).toHaveBeenCalledWith(
       actions.updateDownloadTotalInterrogation({ totalInterrogation: 2 }),
     )
+
+    // insert interrogations in data store, setting them as not updated locally
+    expect(mockDataStore.updateInterrogation).toHaveBeenCalledTimes(2)
+    expect(mockDataStore.updateInterrogation).toHaveBeenCalledWith({
+      ...interro1,
+      hasBeenUpdated: false,
+    })
+    expect(mockDataStore.updateInterrogation).toHaveBeenCalledWith({
+      ...interro2,
+      hasBeenUpdated: false,
+    })
 
     // Check interrogation actions
     const downloadInterrogationCalls = mockDispatch.mock.calls.filter(

--- a/src/core/usecases/synchronizeData/thunks.ts
+++ b/src/core/usecases/synchronizeData/thunks.ts
@@ -413,7 +413,7 @@ export const thunks = {
         if (interrogations) {
           // Filter interrogations to only upload those that have been updated
           const interrogationsToUpload = interrogations.filter(
-            (interrogation) => interrogation.hasBeenUpdated === true,
+            (interrogation) => (interrogation.hasBeenUpdated ?? true) === true,
           )
 
           dispatch(

--- a/src/core/usecases/synchronizeData/thunks.ts
+++ b/src/core/usecases/synchronizeData/thunks.ts
@@ -13,6 +13,7 @@ import {
   getOldExternalCacheNames,
   getResourcesFromExternalQuestionnaire,
 } from '@/core/tools/externalResources'
+import { interrogationFromLocalInterrogation } from '@/utils/interrogation'
 
 import { actions, name } from './state'
 
@@ -410,51 +411,68 @@ export const thunks = {
         const deletedParadataIds = new Set<string>()
 
         if (interrogations) {
+          // Filter interrogations to only upload those that have been updated
+          const interrogationsToUpload = interrogations.filter(
+            (interrogation) => interrogation.hasBeenUpdated === true,
+          )
+
           dispatch(
             actions.setUploadTotalInterrogation({
-              totalInterrogation: interrogations.length ?? 0,
+              totalInterrogation: interrogationsToUpload.length ?? 0,
             }),
           )
 
-          const interrogationPromises = interrogations.map((interrogation) =>
-            queenApi
-              .putInterrogation(interrogation)
-              .catch((error: AxiosError) => {
-                // handle response 423 as a success
-                if (error.response!.status === 423) {
-                  return Promise.resolve()
-                }
-                if (
-                  error.response &&
-                  [400, 403, 404, 500].includes(error.response.status)
-                ) {
-                  return queenApi
-                    .postInterrogationInTemp(interrogation)
-                    .then(() => {
-                      localSyncStorage.addIdToInterrogationsInTempZone(
-                        interrogation.id,
-                      )
-                      dataStore.deleteParadata(interrogation.id)
-                      deletedParadataIds.add(interrogation.id)
-                    })
-                    .catch((postError: Error) => {
-                      console.error(
-                        'Error: Unable to post interrogation in tempZone',
-                        postError,
-                      )
-                      throw postError
-                    })
-                }
-                throw error
-              })
-              .then(() => dataStore.deleteInterrogation(interrogation.id))
-              .then(() => {
-                dispatch(actions.uploadInterrogationCompleted())
-              })
-              .catch((error) => {
-                console.error('Error: Unable to upload data', error)
-                throw error
-              }),
+          const interrogationPromises = interrogationsToUpload.map(
+            (localInterrogation) => {
+              // Create a copy of the interrogation without the hasBeenUpdated field for API
+              const interrogation =
+                interrogationFromLocalInterrogation(localInterrogation)
+
+              return queenApi
+                .putInterrogation(interrogation)
+                .catch((error: AxiosError) => {
+                  // handle response 423 as a success
+                  if (error.response!.status === 423) {
+                    return Promise.resolve()
+                  }
+                  if (
+                    error.response &&
+                    [400, 403, 404, 500].includes(error.response.status)
+                  ) {
+                    return queenApi
+                      .postInterrogationInTemp(interrogation)
+                      .then(() => {
+                        localSyncStorage.addIdToInterrogationsInTempZone(
+                          interrogation.id,
+                        )
+                        dataStore.deleteParadata(interrogation.id)
+                        deletedParadataIds.add(interrogation.id)
+                      })
+                      .catch((postError: Error) => {
+                        console.error(
+                          'Error: Unable to post interrogation in tempZone',
+                          postError,
+                        )
+                        throw postError
+                      })
+                  }
+                  throw error
+                })
+                .then(() => {
+                  // Set locally the interrogation as not updated after successful upload.
+                  return dataStore.updateInterrogation({
+                    ...localInterrogation,
+                    hasBeenUpdated: false,
+                  })
+                })
+                .then(() => {
+                  dispatch(actions.uploadInterrogationCompleted())
+                })
+                .catch((error) => {
+                  console.error('Error: Unable to upload data', error)
+                  throw error
+                })
+            },
           )
           await Promise.all(interrogationPromises)
         }

--- a/src/core/usecases/synchronizeData/thunks.ts
+++ b/src/core/usecases/synchronizeData/thunks.ts
@@ -212,7 +212,10 @@ export const thunks = {
 
         prInterrogations = Promise.all(
           interrogations.map((interrogation) => {
-            dataStore.updateInterrogation(interrogation)
+            dataStore.updateInterrogation({
+              ...interrogation,
+              hasBeenUpdated: false,
+            })
             if (
               questionnaireIdsInSuccess.includes(interrogation.questionnaireId)
             ) {

--- a/src/utils/interrogation.ts
+++ b/src/utils/interrogation.ts
@@ -1,0 +1,10 @@
+import type { Interrogation, LocalInterrogation } from '@/core/model'
+
+export function interrogationFromLocalInterrogation(
+  localInterrogation: LocalInterrogation,
+): Interrogation {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { hasBeenUpdated, ...interrogation } = localInterrogation
+
+  return interrogation
+}


### PR DESCRIPTION
During synchronization, upload only interrogations updated locally since it was last sent to the server.
Handled in local storage by adding `hasBeenUpdated` boolean

⚠️ API does not evolve, so it does not handle this boolean. Interrogations must be sent without it.

⚠️ Dexie migration was needed to force all existing interrogations to be sent during the first synchronization following this application update