### PR TITLE
feat: download only new interrogations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Improve synchronization performance : for download step, the list of interrogations is now retrieved from local storage (given by the parent app). If there is nothing in local storage, we keep the old implementation using api.
+- Improve synchronization performance : for download step, the list of interrogations is now retrieved from local storage (given by the parent app). If there is nothing in local storage, we keep the old implementation using api. Furthermore, we now download only new interrogations, we don't download anymore the interrogations that were already locally.
 - Improve synchronization performance : for upload step, we now upload only interrogations that have been locally updated since it was last sent to the server.
 
 ## [3.3.2](https://github.com/InseeFr/Drama-Queen/releases/tag/3.3.2) - 2026-04-14

--- a/src/core/ports/DataStore.ts
+++ b/src/core/ports/DataStore.ts
@@ -3,7 +3,7 @@ import type { LocalInterrogation, Paradata, TelemetryEvent } from '@/core/model'
 export type DataStore = {
   updateInterrogation: (interrogation: LocalInterrogation) => Promise<string>
   deleteInterrogation: (id: string) => Promise<void>
-  getAllInterrogations: () => Promise<LocalInterrogation[] | undefined>
+  getAllInterrogations: () => Promise<LocalInterrogation[]>
   getInterrogation: (id: string) => Promise<LocalInterrogation | undefined>
   getAllParadata: () => Promise<Paradata[] | undefined>
   deleteParadata: (id: string) => Promise<void>

--- a/src/core/usecases/synchronizeData/thunks.test.ts
+++ b/src/core/usecases/synchronizeData/thunks.test.ts
@@ -70,7 +70,100 @@ describe('download thunk', () => {
     localStorage.clear()
   })
 
-  it('should successfully download interrogations', async () => {
+  it('should only download new interrogations not already in local datastore', async () => {
+    // override global mock value of external resources url
+    vi.doMock('@/core/constants', () => ({
+      EXTERNAL_RESOURCES_URL: '',
+      LUNATIC_MODEL_VERSION_BREAKING: '2.2.10',
+    }))
+    localStorage.setItem(
+      'SYNCHRONIZATION_INTERROGATION_IDS',
+      JSON.stringify(['interro1', 'interro2', 'interro3']),
+    )
+    // Re-import after mocking
+    const { thunks } = await import('./thunks')
+
+    const interro1: Interrogation = {
+      id: 'interro1',
+      questionnaireId: 'q1',
+      data: {},
+    }
+    const interro2: Interrogation = {
+      id: 'interro2',
+      questionnaireId: 'q1',
+      data: {},
+    }
+    const interro3: Interrogation = {
+      id: 'interro3',
+      questionnaireId: 'q1',
+      data: {},
+    }
+    const interro4: Interrogation = {
+      id: 'interro4',
+      questionnaireId: 'q1',
+      data: {},
+    }
+
+    // Mock that interro1 already exists in local datastore, but interro2 and interro4 are new
+    const existingInterrogations = [interro1, interro4]
+    vi.mocked(mockDataStore.getAllInterrogations).mockResolvedValue(
+      existingInterrogations,
+    )
+
+    // Fetch only interro2 & interro3 (interro1 is already local)
+    vi.mocked(mockQueenApi.getInterrogation)
+      .mockResolvedValueOnce(interro2)
+      .mockResolvedValueOnce(interro3)
+    vi.mocked(mockQueenApi.getQuestionnaire).mockResolvedValue({ id: 'q1' })
+
+    await thunks.download()(mockDispatch, mockGetState, mockContext as any)
+
+    expect(mockDispatch).toHaveBeenCalledWith(actions.runningDownload())
+
+    // Total interrogation to download : interrogations that are fetched
+    expect(mockDispatch).toHaveBeenCalledWith(
+      actions.updateDownloadTotalInterrogation({ totalInterrogation: 2 }),
+    )
+
+    // Insert new interrogations in local datastore
+    expect(mockDataStore.updateInterrogation).toHaveBeenCalledTimes(2)
+    expect(mockDataStore.updateInterrogation).toHaveBeenCalledWith({
+      ...interro2,
+      hasBeenUpdated: false,
+    })
+    expect(mockDataStore.updateInterrogation).toHaveBeenCalledWith({
+      ...interro3,
+      hasBeenUpdated: false,
+    })
+
+    // Only new interrogations should be marked as completed
+    const downloadInterrogationCalls = mockDispatch.mock.calls.filter(
+      ([action]) =>
+        action.type === actions.downloadInterrogationCompleted().type,
+    )
+    expect(downloadInterrogationCalls).toHaveLength(2)
+
+    expect(mockDispatch).toHaveBeenCalledWith(actions.downloadCompleted())
+
+    // Only the new interrogation should be marked as success
+    expect(
+      mockLocalSyncStorage.addIdToInterrogationsSuccess,
+    ).toHaveBeenCalledWith('interro2')
+    expect(
+      mockLocalSyncStorage.addIdToInterrogationsSuccess,
+    ).toHaveBeenCalledWith('interro3')
+    expect(
+      mockLocalSyncStorage.addIdToInterrogationsSuccess,
+    ).not.toHaveBeenCalledWith('interro1')
+    expect(
+      mockLocalSyncStorage.addIdToInterrogationsSuccess,
+    ).not.toHaveBeenCalledWith('interro4')
+
+    // Ensure the list of interrogation ids is cleared from local storage
+    expect(localStorage.getItem('SYNCHRONIZATION_INTERROGATION_IDS')).toBeNull()
+  })
+
+  it('should download all interrogations when local datastore is empty', async () => {
     // override global mock value of external resources url
     vi.doMock('@/core/constants', () => ({
       EXTERNAL_RESOURCES_URL: '',
@@ -93,6 +186,9 @@ describe('download thunk', () => {
       questionnaireId: 'q1',
       data: {},
     }
+
+    // Mock that no interrogations exist in local datastore (both are new)
+    vi.mocked(mockDataStore.getAllInterrogations).mockResolvedValue([])
 
     vi.mocked(mockQueenApi.getInterrogation)
       .mockResolvedValueOnce(interro1)

--- a/src/core/usecases/synchronizeData/thunks.ts
+++ b/src/core/usecases/synchronizeData/thunks.ts
@@ -130,22 +130,33 @@ export const thunks = {
       let questionnaires: LunaticSource[] = []
       let prInterrogations
 
-      // get interrogation ids from local storage
-      const interrogationIds = getInterrogationIds()
+      // get expected interrogation ids from local storage
+      const expectedInterrogationIds = getExpectedInterrogationIds()
 
-      if (interrogationIds) {
+      if (expectedInterrogationIds) {
         /*
-         * get interrogations
+         * get new interrogations
          */
+
+        const localInterrogations = await dataStore.getAllInterrogations()
+        const localInterrogationIds = localInterrogations?.map(
+          (interrogation) => interrogation.id,
+        )
+
+        // create list of interrogation ids that are not currently in local datastore
+        const newInterrogationIds = expectedInterrogationIds.filter(
+          (id) => !localInterrogationIds.includes(id),
+        )
 
         dispatch(
           actions.updateDownloadTotalInterrogation({
-            totalInterrogation: interrogationIds.length,
+            totalInterrogation: newInterrogationIds.length,
           }),
         )
 
-        const interrogationsToProcess = await Promise.all(
-          interrogationIds.map((id) =>
+        // get only new interrogations
+        const newInterrogations = await Promise.all(
+          newInterrogationIds.map((id) =>
             queenApi.getInterrogation(id).catch((error) => {
               if (
                 error instanceof AxiosError &&
@@ -163,7 +174,7 @@ export const thunks = {
           ),
         )
 
-        const interrogations = interrogationsToProcess.filter(
+        const interrogations = newInterrogations.filter(
           (interrogation): interrogation is Interrogation => !!interrogation,
         )
 
@@ -388,7 +399,7 @@ export const thunks = {
 
     try {
       // Get interrogation IDs from local storage (provided by pilotage)
-      const localStorageInterrogationIds = getInterrogationIds()
+      const localStorageInterrogationIds = getExpectedInterrogationIds()
 
       // No interrogation IDs found in local storage, skipping cleanup
       if (!localStorageInterrogationIds) {
@@ -582,7 +593,7 @@ function deduplicate<T>(items: (T | undefined)[]): T[] {
 /**
  * Get the list of interrogations ids from local storage
  */
-function getInterrogationIds() {
+function getExpectedInterrogationIds() {
   const localStorageInterrogationsValue = localStorage.getItem(
     INTERROGATIONS_LIST_LOCAL_STORAGE_KEY,
   )


### PR DESCRIPTION
During synchronization, download only interrogations that are not already in index DB.

We assume temporarily we no longer update the link interro*questionnaire for interrogations that are already in index DB. Will be done in another PR and will be deployed together