### PR TITLE
feat(synchronize): update interrogation questionnaire link

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "drama-queen",
   "private": true,
-  "version": "3.3.1-rc-synchronization-optimization.3",
+  "version": "3.3.1-rc-interrogations-questionnaire-link.0",
   "type": "module",
   "scripts": {
     "generate-routes": "tsr generate",

--- a/src/core/adapters/queenApi/default.ts
+++ b/src/core/adapters/queenApi/default.ts
@@ -4,6 +4,7 @@ import type {
   Campaign,
   IdAndQuestionnaireId,
   Interrogation,
+  InterrogationAndQuestionnaireId,
   Nomenclature,
   Questionnaire,
   RequiredNomenclatures,
@@ -19,6 +20,7 @@ import {
   nomenclatureSchema,
   requiredNomenclaturesSchema,
 } from './parserSchema'
+import { interrogationQuestionnaireLink } from './parserSchema/interrogationQuestionnaireLink'
 
 export function createApiClient(params: {
   apiUrl: string
@@ -78,6 +80,14 @@ export function createApiClient(params: {
         >(`/api/interrogations/${idInterrogation}`)
         .then(({ data }) =>
           interrogationSchema.parse({ id: idInterrogation, ...data }),
+        ),
+    getInterrogationsQuestionnaireLink: (interrogationIds) =>
+      axiosInstance
+        .post<
+          InterrogationAndQuestionnaireId[]
+        >(`/api/interrogations/questionnaire-link`, interrogationIds)
+        .then(({ data }) =>
+          data.map((link) => interrogationQuestionnaireLink.parse(link)),
         ),
     putInterrogation: (interrogation) =>
       axiosInstance

--- a/src/core/adapters/queenApi/mock.ts
+++ b/src/core/adapters/queenApi/mock.ts
@@ -15,6 +15,7 @@ export function createApiClient(): QueenApi {
           idInterrogation: 'interro2',
         }),
       ]),
+    getInterrogationsQuestionnaireLink: () => Promise.resolve([]),
     fetchMoved: () => Promise.resolve([{ id: 'interro2' }]),
     syncInterrogation: (idInterrogation) =>
       Promise.resolve(

--- a/src/core/adapters/queenApi/parserSchema/interrogationQuestionnaireLink.ts
+++ b/src/core/adapters/queenApi/parserSchema/interrogationQuestionnaireLink.ts
@@ -1,0 +1,9 @@
+import z from 'zod'
+
+import type { InterrogationAndQuestionnaireId } from '@/core/model'
+
+export const interrogationQuestionnaireLink: z.ZodType<InterrogationAndQuestionnaireId> =
+  z.object({
+    interrogationId: z.string(),
+    questionnaireId: z.string(),
+  })

--- a/src/core/model/IdAndQuestionnaireId.ts
+++ b/src/core/model/IdAndQuestionnaireId.ts
@@ -2,3 +2,8 @@ export type IdAndQuestionnaireId = {
   id: string
   questionnaireId: string
 }
+
+export type InterrogationAndQuestionnaireId = {
+  interrogationId: string
+  questionnaireId: string
+}

--- a/src/core/ports/QueenApi.ts
+++ b/src/core/ports/QueenApi.ts
@@ -2,6 +2,7 @@ import type {
   Campaign,
   IdAndQuestionnaireId,
   Interrogation,
+  InterrogationAndQuestionnaireId,
   Nomenclature,
   Paradata,
   Questionnaire,
@@ -19,6 +20,9 @@ export type QueenApi = {
    * /api/survey-units/interviewer
    */
   getInterrogations: () => Promise<Interrogation[]>
+  getInterrogationsQuestionnaireLink: (
+    interrogationIds: string[],
+  ) => Promise<InterrogationAndQuestionnaireId[]>
   getInterrogation: (idInterrogation: string) => Promise<Interrogation>
   putInterrogation: (interrogation: Interrogation) => Promise<void>
   syncInterrogation: (idInterrogation: string) => Promise<Interrogation>

--- a/src/core/usecases/synchronizeData/thunks.test.ts
+++ b/src/core/usecases/synchronizeData/thunks.test.ts
@@ -122,6 +122,9 @@ describe('download thunk', () => {
 
     vi.mocked(mockQueenApi.getQuestionnaire).mockResolvedValue({ id: 'q1' })
 
+    // Mock successful updateInterrogation response
+    vi.mocked(mockDataStore.updateInterrogation).mockResolvedValue('interro3')
+
     await thunks.download()(mockDispatch, mockGetState, mockContext as any)
 
     expect(mockDispatch).toHaveBeenCalledWith(actions.runningDownload())
@@ -194,6 +197,11 @@ describe('download thunk', () => {
       .mockResolvedValueOnce(interro2)
 
     vi.mocked(mockQueenApi.getQuestionnaire).mockResolvedValue({ id: 'q1' })
+
+    // Mock successful updateInterrogation responses
+    vi.mocked(mockDataStore.updateInterrogation)
+      .mockResolvedValue('interro1')
+      .mockResolvedValue('interro2')
 
     await thunks.download()(mockDispatch, mockGetState, mockContext as any)
 
@@ -371,6 +379,9 @@ describe('download thunk', () => {
     vi.mocked(mockQueenApi.getQuestionnaire)
       .mockResolvedValue({ id: 'q1' })
       .mockResolvedValue({ id: 'q2' })
+
+    // Mock successful updateInterrogation response
+    vi.mocked(mockDataStore.updateInterrogation).mockResolvedValue('interro2')
 
     await thunks.download()(mockDispatch, mockGetState, mockContext as any)
 

--- a/src/core/usecases/synchronizeData/thunks.test.ts
+++ b/src/core/usecases/synchronizeData/thunks.test.ts
@@ -24,6 +24,7 @@ const mockGetState: () => {
 
 const mockDataStore = {
   getAllInterrogations: vi.fn(),
+  getInterrogation: vi.fn(),
   updateInterrogation: vi.fn(),
   deleteInterrogation: vi.fn(),
   getAllParadata: vi.fn(),
@@ -35,6 +36,7 @@ const mockQueenApi = {
   getQuestionnaire: vi.fn(),
   getInterrogationsIdsAndQuestionnaireIdsByCampaign: vi.fn(),
   getInterrogation: vi.fn(),
+  getInterrogationsQuestionnaireLink: vi.fn(),
   putInterrogation: vi.fn(),
   postInterrogationInTemp: vi.fn(),
   fetchMoved: vi.fn(),
@@ -66,7 +68,7 @@ describe('download thunk', () => {
   })
 
   afterEach(() => {
-    vi.clearAllMocks()
+    vi.resetAllMocks()
     localStorage.clear()
   })
 
@@ -76,9 +78,10 @@ describe('download thunk', () => {
       EXTERNAL_RESOURCES_URL: '',
       LUNATIC_MODEL_VERSION_BREAKING: '2.2.10',
     }))
+    // Set expected interrogation to have locally
     localStorage.setItem(
       'SYNCHRONIZATION_INTERROGATION_IDS',
-      JSON.stringify(['interro1', 'interro2', 'interro3']),
+      JSON.stringify(['interro1', 'interro3']),
     )
     // Re-import after mocking
     const { thunks } = await import('./thunks')
@@ -98,39 +101,38 @@ describe('download thunk', () => {
       questionnaireId: 'q1',
       data: {},
     }
-    const interro4: Interrogation = {
-      id: 'interro4',
-      questionnaireId: 'q1',
-      data: {},
-    }
 
-    // Mock that interro1 already exists in local datastore, but interro2 and interro4 are new
-    const existingInterrogations = [interro1, interro4]
+    // Mock that interro1 are already exists in local datastore, but interro3 is new
+    const existingInterrogations = [interro1, interro2]
     vi.mocked(mockDataStore.getAllInterrogations).mockResolvedValue(
       existingInterrogations,
     )
 
-    // Fetch only interro2 & interro3 (interro1 is already local)
-    vi.mocked(mockQueenApi.getInterrogation)
-      .mockResolvedValueOnce(interro2)
-      .mockResolvedValueOnce(interro3)
+    vi.mocked(mockDataStore.getInterrogation).mockResolvedValueOnce(interro1)
+
+    // Fetch only interro3 (interro1 is already local, interro2 is not expected)
+    vi.mocked(mockQueenApi.getInterrogation).mockResolvedValueOnce(interro3)
+
+    // No change of questionnaire for existing interrogations
+    vi.mocked(
+      mockQueenApi.getInterrogationsQuestionnaireLink,
+    ).mockResolvedValue([
+      { interrogationId: 'interro1', questionnaireId: 'q1' },
+    ])
+
     vi.mocked(mockQueenApi.getQuestionnaire).mockResolvedValue({ id: 'q1' })
 
     await thunks.download()(mockDispatch, mockGetState, mockContext as any)
 
     expect(mockDispatch).toHaveBeenCalledWith(actions.runningDownload())
 
-    // Total interrogation to download : interrogations that are fetched
+    // Total interrogation to process during download step : expected interrogations (new & existing ones)
     expect(mockDispatch).toHaveBeenCalledWith(
       actions.updateDownloadTotalInterrogation({ totalInterrogation: 2 }),
     )
 
-    // Insert new interrogations in local datastore
-    expect(mockDataStore.updateInterrogation).toHaveBeenCalledTimes(2)
-    expect(mockDataStore.updateInterrogation).toHaveBeenCalledWith({
-      ...interro2,
-      hasBeenUpdated: false,
-    })
+    // Insert new interrogation in local datastore
+    expect(mockDataStore.updateInterrogation).toHaveBeenCalledTimes(1)
     expect(mockDataStore.updateInterrogation).toHaveBeenCalledWith({
       ...interro3,
       hasBeenUpdated: false,
@@ -145,19 +147,16 @@ describe('download thunk', () => {
 
     expect(mockDispatch).toHaveBeenCalledWith(actions.downloadCompleted())
 
-    // Only the new interrogation should be marked as success
+    // Only the expected interrogations should be marked as success
     expect(
       mockLocalSyncStorage.addIdToInterrogationsSuccess,
-    ).toHaveBeenCalledWith('interro2')
+    ).toHaveBeenCalledTimes(2)
+    expect(
+      mockLocalSyncStorage.addIdToInterrogationsSuccess,
+    ).toHaveBeenCalledWith('interro1')
     expect(
       mockLocalSyncStorage.addIdToInterrogationsSuccess,
     ).toHaveBeenCalledWith('interro3')
-    expect(
-      mockLocalSyncStorage.addIdToInterrogationsSuccess,
-    ).not.toHaveBeenCalledWith('interro1')
-    expect(
-      mockLocalSyncStorage.addIdToInterrogationsSuccess,
-    ).not.toHaveBeenCalledWith('interro4')
 
     // Ensure the list of interrogation ids is cleared from local storage
     expect(localStorage.getItem('SYNCHRONIZATION_INTERROGATION_IDS')).toBeNull()
@@ -193,6 +192,7 @@ describe('download thunk', () => {
     vi.mocked(mockQueenApi.getInterrogation)
       .mockResolvedValueOnce(interro1)
       .mockResolvedValueOnce(interro2)
+
     vi.mocked(mockQueenApi.getQuestionnaire).mockResolvedValue({ id: 'q1' })
 
     await thunks.download()(mockDispatch, mockGetState, mockContext as any)
@@ -234,7 +234,7 @@ describe('download thunk', () => {
     expect(localStorage.getItem('SYNCHRONIZATION_INTERROGATION_IDS')).toBeNull()
   })
 
-  it('should successfully download questionnaires', async () => {
+  it('should update existing interrogations with new questionnaire IDs', async () => {
     // override global mock value of external resources url
     vi.doMock('@/core/constants', () => ({
       EXTERNAL_RESOURCES_URL: '',
@@ -247,9 +247,127 @@ describe('download thunk', () => {
     // Re-import after mocking
     const { thunks } = await import('./thunks')
 
-    vi.mocked(mockQueenApi.getInterrogation)
-      .mockResolvedValueOnce({ id: 'interro1', questionnaireId: 'q1' })
-      .mockResolvedValueOnce({ id: 'interro2', questionnaireId: 'q2' })
+    const existingInterro1: Interrogation = {
+      id: 'interro1',
+      questionnaireId: 'q1-old',
+      data: {},
+    }
+    const existingInterro2: Interrogation = {
+      id: 'interro2',
+      questionnaireId: 'q2-old',
+      data: {},
+    }
+
+    // Mock that both interrogations already exist in local datastore
+    const existingInterrogations = [existingInterro1, existingInterro2]
+    vi.mocked(mockDataStore.getAllInterrogations).mockResolvedValue(
+      existingInterrogations,
+    )
+
+    vi.mocked(mockDataStore.getInterrogation)
+      .mockResolvedValueOnce(existingInterro1)
+      .mockResolvedValueOnce(existingInterro2)
+
+    // Mock that no new interrogations are fetched (empty array)
+    vi.mocked(mockQueenApi.getInterrogation).mockResolvedValue(undefined)
+
+    // Mock the new API call to get updated questionnaire IDs for existing interrogations
+    vi.mocked(
+      mockQueenApi.getInterrogationsQuestionnaireLink,
+    ).mockResolvedValue([
+      { interrogationId: 'interro1', questionnaireId: 'q1-new' },
+      { interrogationId: 'interro2', questionnaireId: 'q2-new' },
+    ])
+
+    vi.mocked(mockQueenApi.getQuestionnaire)
+      .mockResolvedValueOnce({ id: 'q1-new' })
+      .mockResolvedValueOnce({ id: 'q2-new' })
+
+    await thunks.download()(mockDispatch, mockGetState, mockContext as any)
+
+    expect(mockDispatch).toHaveBeenCalledWith(actions.runningDownload())
+    expect(mockDispatch).toHaveBeenCalledWith(
+      actions.updateDownloadTotalInterrogation({ totalInterrogation: 2 }),
+    )
+
+    // Should update existing interrogations with new questionnaire IDs
+    expect(mockDataStore.updateInterrogation).toHaveBeenCalledTimes(2)
+    expect(mockDataStore.updateInterrogation).toHaveBeenCalledWith({
+      ...existingInterro1,
+      questionnaireId: 'q1-new',
+    })
+    expect(mockDataStore.updateInterrogation).toHaveBeenCalledWith({
+      ...existingInterro2,
+      questionnaireId: 'q2-new',
+    })
+
+    // Check interrogation actions
+    const downloadInterrogationCalls = mockDispatch.mock.calls.filter(
+      ([action]) =>
+        action.type === actions.downloadInterrogationCompleted().type,
+    )
+    expect(downloadInterrogationCalls).toHaveLength(2)
+
+    expect(mockDispatch).toHaveBeenCalledWith(actions.downloadCompleted())
+
+    // Check questionnaire actions
+    const downloadQuestionnaireCalls = mockDispatch.mock.calls.filter(
+      ([action]) => action.type === actions.downloadSurveyCompleted().type,
+    )
+    expect(mockQueenApi.getQuestionnaire).toHaveBeenCalledTimes(2)
+    expect(downloadQuestionnaireCalls).toHaveLength(2)
+
+    // Ensure the local sync storage actions were called
+    expect(
+      mockLocalSyncStorage.addIdToInterrogationsSuccess,
+    ).toHaveBeenCalledWith('interro1')
+    expect(
+      mockLocalSyncStorage.addIdToInterrogationsSuccess,
+    ).toHaveBeenCalledWith('interro2')
+
+    // Ensure the list of interrogation ids is cleared from local storage
+    expect(localStorage.getItem('SYNCHRONIZATION_INTERROGATION_IDS')).toBeNull()
+  })
+
+  it('should successfully download questionnaires for new interrogations', async () => {
+    // override global mock value of external resources url
+    vi.doMock('@/core/constants', () => ({
+      EXTERNAL_RESOURCES_URL: '',
+      LUNATIC_MODEL_VERSION_BREAKING: '2.2.10',
+    }))
+    localStorage.setItem(
+      'SYNCHRONIZATION_INTERROGATION_IDS',
+      JSON.stringify(['interro1', 'interro2']),
+    )
+    // Re-import after mocking
+    const { thunks } = await import('./thunks')
+
+    const interro1: Interrogation = {
+      id: 'interro1',
+      questionnaireId: 'q1',
+      data: {},
+    }
+    const interro2: Interrogation = {
+      id: 'interro2',
+      questionnaireId: 'q2',
+      data: {},
+    }
+
+    // Mock that interro1 already exists in local datastore, but  interro3 is new
+    const existingInterrogations = [interro1]
+    vi.mocked(mockDataStore.getAllInterrogations).mockResolvedValue(
+      existingInterrogations,
+    )
+
+    vi.mocked(mockQueenApi.getInterrogation).mockResolvedValueOnce(interro2)
+
+    // No change of questionnaire for existing interrogations
+    vi.mocked(
+      mockQueenApi.getInterrogationsQuestionnaireLink,
+    ).mockResolvedValue([
+      { interrogationId: 'interro1', questionnaireId: 'q1' },
+    ])
+
     vi.mocked(mockQueenApi.getQuestionnaire)
       .mockResolvedValue({ id: 'q1' })
       .mockResolvedValue({ id: 'q2' })
@@ -258,10 +376,11 @@ describe('download thunk', () => {
 
     expect(mockDispatch).toHaveBeenCalledWith(actions.runningDownload())
 
-    // Check interrogation actions
+    // Check questionnaire actions
     const downloadQuestionnaireCalls = mockDispatch.mock.calls.filter(
       ([action]) => action.type === actions.downloadSurveyCompleted().type,
     )
+    expect(mockQueenApi.getQuestionnaire).toHaveBeenCalledTimes(2)
     expect(downloadQuestionnaireCalls).toHaveLength(2)
 
     expect(mockDispatch).toHaveBeenCalledWith(actions.downloadCompleted())
@@ -287,6 +406,31 @@ describe('download thunk', () => {
     )
     // Re-import after mocking
     const { thunks } = await import('./thunks')
+
+    const interro1: Interrogation = {
+      id: 'interro1',
+      questionnaireId: 'q1',
+      data: {},
+    }
+    const interro2: Interrogation = {
+      id: 'interro2',
+      questionnaireId: 'q2',
+      data: {},
+    }
+
+    // Mock that interro1 already exists in local datastore, but  interro3 is new
+    const existingInterrogations = [interro1, interro2]
+    vi.mocked(mockDataStore.getAllInterrogations).mockResolvedValue(
+      existingInterrogations,
+    )
+
+    // No change of questionnaire for existing interrogations
+    vi.mocked(
+      mockQueenApi.getInterrogationsQuestionnaireLink,
+    ).mockResolvedValue([
+      { interrogationId: 'interro1', questionnaireId: 'q1' },
+      { interrogationId: 'interro2', questionnaireId: 'q2' },
+    ])
 
     vi.mocked(mockQueenApi.getInterrogation)
       .mockResolvedValueOnce({ id: 'interro1', questionnaireId: 'q1' })
@@ -331,6 +475,8 @@ describe('download thunk', () => {
     // Re-import after mocking
     const { thunks } = await import('./thunks')
 
+    vi.mocked(mockDataStore.getAllInterrogations).mockResolvedValue([])
+
     await thunks.download()(mockDispatch, mockGetState, mockContext as any)
 
     expect(mockDispatch).toHaveBeenCalledWith(actions.runningDownload())
@@ -356,13 +502,15 @@ describe('download thunk', () => {
     // Re-import after mocking
     const { thunks } = await import('./thunks')
 
+    vi.mocked(mockDataStore.getAllInterrogations).mockResolvedValue([])
+
     vi.mocked(mockQueenApi.getInterrogation).mockRejectedValue(
       new Error('Failed to fetch interrogation'),
     )
 
     await expect(() =>
       thunks.download()(mockDispatch, mockGetState, mockContext as any),
-    ).rejects.toThrowError()
+    ).rejects.toThrow()
 
     expect(mockLocalSyncStorage.addError).toHaveBeenCalledWith(true)
     expect(mockDispatch).toHaveBeenCalledWith(actions.downloadFailed())

--- a/src/core/usecases/synchronizeData/thunks.ts
+++ b/src/core/usecases/synchronizeData/thunks.ts
@@ -143,48 +143,72 @@ export const thunks = {
           (interrogation) => interrogation.id,
         )
 
-        // create list of interrogation ids that are not currently in local datastore
+        // create list of expected interrogation ids that are already in local datastore
+        const existingInterrogationIds = expectedInterrogationIds.filter((id) =>
+          localInterrogationIds.includes(id),
+        )
+
+        // create list of expected interrogation ids that are not already in local datastore
         const newInterrogationIds = expectedInterrogationIds.filter(
           (id) => !localInterrogationIds.includes(id),
         )
 
         dispatch(
           actions.updateDownloadTotalInterrogation({
-            totalInterrogation: newInterrogationIds.length,
+            totalInterrogation: expectedInterrogationIds.length,
           }),
         )
 
         // get only new interrogations
-        const newInterrogations = await Promise.all(
-          newInterrogationIds.map((id) =>
-            queenApi.getInterrogation(id).catch((error) => {
-              if (
-                error instanceof AxiosError &&
-                error.response &&
-                [400, 403, 404, 500].includes(error.response.status)
-              ) {
-                console.error(
-                  `An error occurred while fetching interrogation : ${id}, synchronization continue`,
-                  error,
-                )
-                return
-              }
-              throw error
-            }),
-          ),
-        )
-
-        const interrogations = newInterrogations.filter(
+        const newInterrogations = (
+          await Promise.all(
+            newInterrogationIds.map((id) =>
+              queenApi.getInterrogation(id).catch((error) => {
+                if (
+                  error instanceof AxiosError &&
+                  error.response &&
+                  [400, 403, 404, 500].includes(error.response.status)
+                ) {
+                  console.error(
+                    `An error occurred while fetching interrogation : ${id}, synchronization continue`,
+                    error,
+                  )
+                  return
+                }
+                throw error
+              }),
+            ),
+          )
+        ).filter(
           (interrogation): interrogation is Interrogation => !!interrogation,
         )
+
+        /*
+         * update existing interrogations
+         */
+
+        // get actualized link between interrogation*questionnaire for interrogations that are already in local datastore
+        const existingInterrogationsQuestionnairesIds =
+          existingInterrogationIds.length > 0
+            ? await queenApi.getInterrogationsQuestionnaireLink(
+                existingInterrogationIds,
+              )
+            : [] // avoid unnecessary api call
+
+        // get actualized questionnaire ids for interrogations that are already in local datastore
+        const existingQuestionnaireIds =
+          existingInterrogationsQuestionnairesIds.map(
+            (interrogation) => interrogation.questionnaireId,
+          )
 
         /*
          * questionnaires
          */
 
-        const questionnaireIds = deduplicate(
-          interrogations.map(({ questionnaireId }) => questionnaireId),
-        )
+        const questionnaireIds = deduplicate([
+          ...newInterrogations.map(({ questionnaireId }) => questionnaireId),
+          ...existingQuestionnaireIds,
+        ])
 
         const questionnaireResults = await Promise.all(
           questionnaireIds.map((questionnaireId) =>
@@ -222,8 +246,36 @@ export const thunks = {
          * store interrogations
          */
 
+        // update questionnaireId for existing interrogations in local datastore
+        await Promise.all(
+          existingInterrogationsQuestionnairesIds.map(async (interrogation) => {
+            const localInterrogation = await dataStore.getInterrogation(
+              interrogation.interrogationId,
+            )
+            if (
+              localInterrogation &&
+              localInterrogation.questionnaireId !==
+                interrogation.questionnaireId
+            ) {
+              dataStore.updateInterrogation({
+                ...localInterrogation,
+                questionnaireId: interrogation.questionnaireId,
+              })
+            }
+            if (
+              questionnaireIdsInSuccess.includes(interrogation.questionnaireId)
+            ) {
+              localSyncStorage.addIdToInterrogationsSuccess(
+                interrogation.interrogationId,
+              )
+            }
+            dispatch(actions.downloadInterrogationCompleted())
+          }),
+        )
+
+        // store new interrogations
         prInterrogations = Promise.all(
-          interrogations.map((interrogation) => {
+          newInterrogations.map((interrogation) => {
             dataStore.updateInterrogation({
               ...interrogation,
               hasBeenUpdated: false,

--- a/src/core/usecases/synchronizeData/thunks.ts
+++ b/src/core/usecases/synchronizeData/thunks.ts
@@ -276,16 +276,23 @@ export const thunks = {
         // store new interrogations
         prInterrogations = Promise.all(
           newInterrogations.map((interrogation) => {
-            dataStore.updateInterrogation({
-              ...interrogation,
-              hasBeenUpdated: false,
-            })
-            if (
-              questionnaireIdsInSuccess.includes(interrogation.questionnaireId)
-            ) {
-              localSyncStorage.addIdToInterrogationsSuccess(interrogation.id)
-            }
-            dispatch(actions.downloadInterrogationCompleted())
+            return dataStore
+              .updateInterrogation({
+                ...interrogation,
+                hasBeenUpdated: false,
+              })
+              .then(() => {
+                if (
+                  questionnaireIdsInSuccess.includes(
+                    interrogation.questionnaireId,
+                  )
+                ) {
+                  localSyncStorage.addIdToInterrogationsSuccess(
+                    interrogation.id,
+                  )
+                }
+                dispatch(actions.downloadInterrogationCompleted())
+              })
           }),
         )
       } else {


### PR DESCRIPTION
During synchronization, for download step :
For every interrogations that are expected and that are already in index DB, we check from the API the actualized link between interrogation*questionnaire, in order to update the interrogation locally