### PR TITLE
fix: stop synchro if 500 during put interrogation

### DIFF
--- a/src/core/usecases/synchronizeData/thunks.ts
+++ b/src/core/usecases/synchronizeData/thunks.ts
@@ -558,7 +558,7 @@ export const thunks = {
                   }
                   if (
                     error.response &&
-                    [400, 403, 404, 500].includes(error.response.status)
+                    [400, 403, 404].includes(error.response.status)
                   ) {
                     return queenApi
                       .postInterrogationInTemp(interrogation)


### PR DESCRIPTION
Stop synchro if error 500 during put interrogation

Prevent for doing the post in tempzone when the server is down